### PR TITLE
setTxConfirmed accepts array of txs to match rust function

### DIFF
--- a/example/ldk/index.ts
+++ b/example/ldk/index.ts
@@ -169,7 +169,8 @@ export const getTransactionData = async (
 		txHashes: data,
 		network: selectedNetwork,
 	});
-	if (response.error) {
+
+	if (response.error || !response.data || response.data[0].error) {
 		return transactionData;
 	}
 	const { confirmations, hex: hex_encoded_tx } = response.data[0].result;

--- a/lib/ios/Ldk.m
+++ b/lib/ios/Ldk.m
@@ -49,8 +49,7 @@ RCT_EXTERN_METHOD(addPeer:(NSString *)address
                   resolve:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject)
 RCT_EXTERN_METHOD(setTxConfirmed:(NSString *)header
-                  transaction:(NSString *)transaction
-                  pos:(NSInteger *)pos
+                  txData:(NSArray *)txData
                   height:(NSInteger *)height
                   resolve:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject)

--- a/lib/ios/Ldk.swift
+++ b/lib/ios/Ldk.swift
@@ -329,7 +329,7 @@ class Ldk: NSObject {
     }
 
     @objc
-    func setTxConfirmed(_ header: NSString, transaction: NSString, pos: NSInteger, height: NSInteger, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+    func setTxConfirmed(_ header: NSString, txData: NSArray, height: NSInteger, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
         guard let channelManager = channelManager else {
             return handleReject(reject, .init_channel_manager)
         }
@@ -338,16 +338,20 @@ class Ldk: NSObject {
             return handleReject(reject, .init_chain_monitor)
         }
 
-        let txData = [C2Tuple_usizeTransactionZ.new(a: UInt(pos), b: String(transaction).hexaBytes)]
-
+        var confirmTxData: [C2Tuple_usizeTransactionZ] = []
+        for tx in txData {
+            let d = tx as! NSDictionary
+            confirmTxData.append(C2Tuple_usizeTransactionZ.new(a: d["pos"] as! UInt, b: (d["transaction"] as! String).hexaBytes))
+        }
+        
         channelManager.as_Confirm().transactions_confirmed(
             header: String(header).hexaBytes,
-            txdata: txData,
+            txdata: confirmTxData,
             height: UInt32(height)
         )
         chainMonitor.as_Confirm().transactions_confirmed(
             header: String(header).hexaBytes,
-            txdata: txData,
+            txdata: confirmTxData,
             height: UInt32(height)
         )
 

--- a/lib/src/ldk.ts
+++ b/lib/src/ldk.ts
@@ -247,17 +247,11 @@ class LDK {
 	 */
 	async setTxConfirmed({
 		header,
-		transaction,
+		txData,
 		height,
-		pos,
 	}: TSetTxConfirmedReq): Promise<Result<string>> {
 		try {
-			const res = await NativeLDK.setTxConfirmed(
-				header,
-				transaction,
-				pos,
-				height,
-			);
+			const res = await NativeLDK.setTxConfirmed(header, txData, height);
 			return ok(res);
 		} catch (e) {
 			return err(e);

--- a/lib/src/lightning-manager.ts
+++ b/lib/src/lightning-manager.ts
@@ -376,8 +376,7 @@ class LightningManager {
 					await ldk.setTxConfirmed({
 						header: response.header,
 						height: response.height,
-						transaction: response.transaction,
-						pos,
+						txData: [{ transaction: response.transaction, pos }], //TODO can be used to batch this call
 					});
 				} else {
 					await ldk.setTxUnconfirmed({

--- a/lib/src/utils/types.ts
+++ b/lib/src/utils/types.ts
@@ -179,8 +179,10 @@ export type TAddPeerReq = {
 
 export type TSetTxConfirmedReq = {
 	header: string;
-	transaction: string;
-	pos: number;
+	txData: {
+		transaction: string;
+		pos: number;
+	}[];
 	height: number;
 };
 


### PR DESCRIPTION
- `setTxConfirmed` closer mirrors rust function now

```js
const res = await ldk.setTxConfirmed({
    header: 'header-hex',
    txData: [{ transaction: 'tx-hex', pos: 0 }, { transaction: 'tx-hex', pos: 1 }],
    height: 12345,
  });
```

- Fixes an unhandled promise exception when a tx is not found in the mempool in example `getTransactionData` function.