### PR TITLE
getLdkStorage Fix

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -282,7 +282,7 @@ PODS:
   - React-jsinspector (0.68.2)
   - React-logger (0.68.2):
     - glog
-  - react-native-ldk (0.0.43):
+  - react-native-ldk (0.0.45):
     - React
   - react-native-randombytes (3.6.1):
     - React-Core
@@ -554,7 +554,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: b7b553412f2ec768fe6c8f27cd6bafdb9d8719e6
   React-jsinspector: c5989c77cb89ae6a69561095a61cce56a44ae8e8
   React-logger: a0833912d93b36b791b7a521672d8ee89107aff1
-  react-native-ldk: dc6e4c247ca9b65b6cba3cd1476834f9c73495cb
+  react-native-ldk: 4fa6b0a0cc13976391b63e3a0355aeeb964d1aab
   react-native-randombytes: 421f1c7d48c0af8dbcd471b0324393ebf8fe7846
   react-native-tcp-socket: c1b7297619616b4c9caae6889bcb0aba78086989
   React-perflogger: a18b4f0bd933b8b24ecf9f3c54f9bf65180f3fe6

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@synonymdev/react-native-ldk",
   "title": "React Native LDK",
-  "version": "0.0.44",
+  "version": "0.0.45",
   "description": "React Native wrapper for LDK",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/lib/src/lightning-manager.ts
+++ b/lib/src/lightning-manager.ts
@@ -447,10 +447,20 @@ class LightningManager {
 	 * @returns {Promise<TLdkStorage>}
 	 */
 	getLdkStorage = async (): Promise<TLdkStorage> => {
-		const ldkStorage = await this.getItem(ELdkStorage.key);
-		return ldkStorage
-			? JSON.parse(ldkStorage)
-			: getDefaultLdkStorageShape(this.seed);
+		try {
+			const ldkStorage = await this.getItem(ELdkStorage.key);
+			if (!ldkStorage) {
+				return getDefaultLdkStorageShape(this.seed);
+			}
+			const parsedldkStorage = JSON.parse(ldkStorage);
+			// If the current seed is not present in the current storage object, add it.
+			if (!(this.seed in parsedldkStorage)) {
+				parsedldkStorage[this.seed] = DefaultLdkDataShape;
+			}
+			return parsedldkStorage;
+		} catch {
+			return getDefaultLdkStorageShape(this.seed);
+		}
 	};
 
 	/**
@@ -459,7 +469,7 @@ class LightningManager {
 	 */
 	getLdkData = async (): Promise<TLdkData> => {
 		const ldkStorage = await this.getLdkStorage();
-		return ldkStorage[this.seed] ? ldkStorage[this.seed] : DefaultLdkDataShape;
+		return ldkStorage[this.seed];
 	};
 
 	/**


### PR DESCRIPTION
This PR:
 - Updates getLdkStorage method in lightning-manager.ts to take multiple accounts into consideration and adds them when necessary.
 - Fixes #18 