### PR TITLE
Add Timestamp To Storage Data

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -282,7 +282,7 @@ PODS:
   - React-jsinspector (0.68.2)
   - React-logger (0.68.2):
     - glog
-  - react-native-ldk (0.0.48):
+  - react-native-ldk (0.0.49):
     - React
   - react-native-randombytes (3.6.1):
     - React-Core
@@ -554,7 +554,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: b7b553412f2ec768fe6c8f27cd6bafdb9d8719e6
   React-jsinspector: c5989c77cb89ae6a69561095a61cce56a44ae8e8
   React-logger: a0833912d93b36b791b7a521672d8ee89107aff1
-  react-native-ldk: a5e851e2695315f3cddb6991dea14e47a524662d
+  react-native-ldk: 431d77fdd78079139a25e41b92b793a961a75db4
   react-native-randombytes: 421f1c7d48c0af8dbcd471b0324393ebf8fe7846
   react-native-tcp-socket: c1b7297619616b4c9caae6889bcb0aba78086989
   React-perflogger: a18b4f0bd933b8b24ecf9f3c54f9bf65180f3fe6

--- a/example/ldk/index.ts
+++ b/example/ldk/index.ts
@@ -117,7 +117,7 @@ export const setupLdk = async (): Promise<Result<string>> => {
 		try {
 			const peersRes = await Promise.all(
 				Object.keys(peers).map(async (peer) => {
-					const addPeer = await ldk.addPeer({
+					const addPeer = await lm.addPeer({
 						...peers[peer],
 						timeout: 5000,
 					});

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@synonymdev/react-native-ldk",
   "title": "React Native LDK",
-  "version": "0.0.48",
+  "version": "0.0.49",
   "description": "React Native wrapper for LDK",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/lib/src/utils/helpers.ts
+++ b/lib/src/utils/helpers.ts
@@ -289,6 +289,7 @@ export const getAllStorageKeys = async (
 		[ELdkData.channelData]: '',
 		[ELdkData.peers]: '',
 		[ELdkData.networkGraph]: '',
+		[ELdkData.timestamp]: '0',
 	};
 	await Promise.all(
 		Object.values(ELdkData).map((ldkDataKey) => {
@@ -297,4 +298,12 @@ export const getAllStorageKeys = async (
 		}),
 	);
 	return storageKeys;
+};
+
+export const parseData = (data: string, fallback: any): any => {
+	try {
+		return data ? JSON.parse(data) : fallback;
+	} catch {
+		return fallback;
+	}
 };

--- a/lib/src/utils/types.ts
+++ b/lib/src/utils/types.ts
@@ -260,6 +260,7 @@ export enum ELdkData {
 	channelData = 'channelData',
 	peers = 'peers',
 	networkGraph = 'networkGraph',
+	timestamp = 'timestamp',
 }
 
 export type TLdkData = {
@@ -267,6 +268,7 @@ export type TLdkData = {
 	[ELdkData.channelData]: TLdkChannelData;
 	[ELdkData.peers]: TLdkPeers;
 	[ELdkData.networkGraph]: TLdkNetworkGraph;
+	[ELdkData.timestamp]: number;
 };
 
 export type TAccountBackup = {
@@ -293,6 +295,7 @@ export const DefaultLdkDataShape: TLdkData = {
 	[ELdkData.channelData]: {},
 	[ELdkData.peers]: [],
 	[ELdkData.networkGraph]: '',
+	[ELdkData.timestamp]: 0,
 };
 
 export type TAvailableNetworks =


### PR DESCRIPTION
This PR:
Adds timestamp information to the LDK account storage and is updated every time the storage is updated. A check has been added to importAccount to ensure the user does not successfully import an old or stale backup unless specifically instructed to overwrite the existing data.

- Adds timestamp to ELdkData, TLdkData & DefaultLdkDataShape in types.ts.
- Adds this.updateStorage to LightningManager class in lightning-manager.ts.
- Adds timestamp condition to importAccount method in lightning-manager.ts.
- Replaces this.setItem with this.updateStorage as needed throughout lightning-manager.ts.
- Creates updateTimestamp method in lightning-manager.ts.
- Creates parseData method in helpers.ts and implemented it as needed in lightning-manager.ts.
- Changes ldk.addPeer to lm.addPeer in setupLdk method in example/ldk/index.ts.