### PR TITLE
Swift/Kotlin exposes keysManager.spend_spendable_outputs

### DIFF
--- a/lib/android/src/main/java/com/reactnativeldk/classes/LdkChannelManagerPersister.kt
+++ b/lib/android/src/main/java/com/reactnativeldk/classes/LdkChannelManagerPersister.kt
@@ -102,7 +102,7 @@ class LdkChannelManagerPersister: ChannelManagerConstructor.EventHandler {
             spendableOutputs.outputs.iterator().forEach {
                 outputs.pushHexString(it.write())
             }
-            body.putArray("outputs", outputs)
+            body.putArray("outputsSerialized", outputs)
             return LdkEventEmitter.send(EventTypes.channel_manager_spendable_outputs, body)
         }
 

--- a/lib/ios/Classes/LdkChannelManagerPersister.swift
+++ b/lib/ios/Classes/LdkChannelManagerPersister.swift
@@ -158,7 +158,7 @@ class LdkChannelManagerPersister: Persister, ExtendedChannelManagerPersister {
             LdkEventEmitter.shared.send(
                 withEvent: .channel_manager_spendable_outputs,
                 body: [
-                    "outputs": spendableOutputs.getOutputs().map { Data($0.write()).hexEncodedString() },
+                    "outputsSerialized": spendableOutputs.getOutputs().map { Data($0.write()).hexEncodedString() },
                 ]
             )
             return

--- a/lib/ios/Ldk.m
+++ b/lib/ios/Ldk.m
@@ -65,6 +65,12 @@ RCT_EXTERN_METHOD(closeChannel:(NSString *)channelId
                   force:(BOOL *)force
                   resolve:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject)
+RCT_EXTERN_METHOD(spendOutputs:(NSArray *)descriptorsSerialized
+                  outputs:(NSArray *)outputs
+                  changeDestinationScript:(NSString *)changeDestinationScript
+                  feeRate:(NSInteger *)feeRate
+                  resolve:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject)
 
 //MARK: Fetch methods
 RCT_EXTERN_METHOD(version:(RCTPromiseResolveBlock)resolve

--- a/lib/ios/Ldk.swift
+++ b/lib/ios/Ldk.swift
@@ -56,6 +56,7 @@ enum LdkErrors: String {
     case claim_funds_failed = "claim_funds_failed"
     case network_graph_restore_failed = "network_graph_restore_failed"
     case channel_close_fail = "channel_close_fail"
+    case spend_outputs_fail = "spend_outputs_fail"
 }
 
 enum LdkCallbackResponses: String {
@@ -425,6 +426,42 @@ class Ldk: NSObject {
         }
     
         return handleResolve(resolve, .close_channel_success)
+    }
+    
+    @objc
+    func spendOutputs(_ descriptorsSerialized: NSArray, outputs: NSArray, changeDestinationScript: NSString, feeRate: NSInteger, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+        guard let keysManager = keysManager else {
+            return handleReject(reject, .init_keys_manager)
+        }
+        
+        var ldkDescriptors: Array<SpendableOutputDescriptor> = []
+        for descriptor in descriptorsSerialized {
+            let read = SpendableOutputDescriptor.read(ser: (descriptor as! String).hexaBytes)
+            
+            guard read.isOk()  else {
+                return handleReject(reject, .spend_outputs_fail, nil, read.getError().debugDescription)
+            }            
+            ldkDescriptors.append(read.getValue()!)
+        }
+        
+        var ldkOutputs: Array<TxOut> = []
+        for output in outputs {
+            let d = output as! NSDictionary
+            ldkOutputs.append(TxOut(script_pubkey: (d["script_pubkey"] as! String).hexaBytes, value: d["value"] as! UInt64))
+        }
+        
+        let res = keysManager.spend_spendable_outputs(
+            descriptors: ldkDescriptors,
+            outputs: ldkOutputs,
+            change_destination_script: String(changeDestinationScript).hexaBytes,
+            feerate_sat_per_1000_weight: UInt32(feeRate)
+        )
+        
+        guard res.isOk() else {
+            return handleReject(reject, .spend_outputs_fail)
+        }
+        
+        return resolve(Data(res.getValue()!).hexEncodedString)
     }
 
     //MARK: Payments

--- a/lib/ios/Ldk.swift
+++ b/lib/ios/Ldk.swift
@@ -461,7 +461,7 @@ class Ldk: NSObject {
             return handleReject(reject, .spend_outputs_fail)
         }
         
-        return resolve(Data(res.getValue()!).hexEncodedString)
+        return resolve(Data(res.getValue()!).hexEncodedString())
     }
 
     //MARK: Payments

--- a/lib/src/ldk.ts
+++ b/lib/src/ldk.ts
@@ -17,6 +17,7 @@ import {
 	TSetTxUnconfirmedReq,
 	TInitNetworkGraphReq,
 	TCloseChannelReq,
+	TSpendOutputsReq,
 } from './utils/types';
 
 const LINKING_ERROR =
@@ -339,6 +340,34 @@ class LDK {
 				channelId,
 				counterPartyNodeId,
 				!!force,
+			);
+			return ok(res);
+		} catch (e) {
+			return err(e);
+		}
+	}
+
+	/**
+	 * Use LDK key manager to spend spendable outputs
+	 * https://docs.rs/lightning/latest/lightning/chain/keysinterface/struct.KeysManager.html#method.spend_spendable_outputs
+	 * @param descriptors
+	 * @param outputs
+	 * @param change_destination_script
+	 * @param feerate_sat_per_1000_weight
+	 * @returns {Promise<Err<unknown> | Ok<Ok<string> | Err<string>>>} (Hex string of the transaction)
+	 */
+	async spendOutputs({
+		descriptorsSerialized,
+		outputs,
+		change_destination_script,
+		feerate_sat_per_1000_weight,
+	}: TSpendOutputsReq): Promise<Result<string>> {
+		try {
+			const res = await NativeLDK.spendOutputs(
+				descriptorsSerialized,
+				outputs,
+				change_destination_script,
+				feerate_sat_per_1000_weight,
 			);
 			return ok(res);
 		} catch (e) {

--- a/lib/src/utils/types.ts
+++ b/lib/src/utils/types.ts
@@ -97,7 +97,7 @@ export type TChannelManagerPendingHtlcsForwardable = {
 	time_forwardable: number;
 };
 export type TChannelManagerSpendableOutputs = {
-	outputs: string[];
+	outputsSerialized: string[];
 };
 export type TChannelManagerChannelClosed = {
 	user_channel_id: number;
@@ -194,6 +194,16 @@ export type TCloseChannelReq = {
 	channelId: string;
 	counterPartyNodeId: string;
 	force?: boolean;
+};
+
+export type TSpendOutputsReq = {
+	descriptorsSerialized: string[];
+	outputs: {
+		script_pubkey: string;
+		value: number;
+	}[];
+	change_destination_script: string;
+	feerate_sat_per_1000_weight: number;
 };
 
 export type TPaymentReq = {


### PR DESCRIPTION
New ldk method:

``` javascript
const spendRes = await ldk.spendOutputs({
	descriptorsSerialized: [abc123...],
	outputs: [], //Shouldn't need to specify this if we're sweeping all funds to dest script
	change_destination_script: 'a91407694cfd2bd43f4e0fe285a4d013456cb58d7eab87',
	feerate_sat_per_1000_weight: 1000, 
});
```

`descriptorsSerialized` is an array of serialized descriptors received from `channel_manager_spendable_outputs` event.

`spendRes.value` is a hex encoded tx that needs to be broadcasted.

`feerate_sat_per_1000_weight` can maybe be changed to an enum if more convenient ('high' | 'normal' | 'low')
