### PR TITLE
Events unsubscribe

### DIFF
--- a/example/App.tsx
+++ b/example/App.tsx
@@ -1,5 +1,5 @@
 import './shim';
-import React, {ReactElement, useCallback, useEffect, useState} from 'react';
+import React, { ReactElement, useEffect, useState } from 'react';
 import {
 	Alert,
 	Button,
@@ -15,7 +15,7 @@ import Clipboard from '@react-native-clipboard/clipboard';
 import { backupAccount, importAccount, setupLdk, syncLdk } from './ldk';
 import { connectToElectrum, subscribeToHeader } from './electrum';
 import ldk from '@synonymdev/react-native-ldk/dist/ldk';
-import lm, {EEventTypes} from '@synonymdev/react-native-ldk';
+import lm, { EEventTypes } from '@synonymdev/react-native-ldk';
 import { peers } from './utils/constants';
 import { createNewAccount } from './utils/helpers';
 import RNFS from 'react-native-fs';
@@ -75,7 +75,9 @@ const App = (): ReactElement => {
 
 	useEffect(() => {
 		if (!logSubscription) {
-			logSubscription = ldk.onEvent(EEventTypes.ldk_log, (log: string) => setLogContent((logs => `${logs}${log}`)));
+			logSubscription = ldk.onEvent(EEventTypes.ldk_log, (log: string) =>
+				setLogContent((logs) => `${logs}${log}`),
+			);
 		}
 
 		return (): void => logSubscription && logSubscription.remove();

--- a/lib/android/src/main/java/com/reactnativeldk/Helpers.kt
+++ b/lib/android/src/main/java/com/reactnativeldk/Helpers.kt
@@ -37,7 +37,7 @@ val Invoice.asJson: WritableMap
         val signedInv = into_signed_raw()
         val rawInvoice = signedInv.raw_invoice()
 
-        result.putInt("amount_milli_satoshis", (amount_milli_satoshis() as Option_u64Z.Some).some.toInt() / 1000)
+        result.putInt("amount_satoshis", (amount_milli_satoshis() as Option_u64Z.Some).some.toInt() / 1000)
         result.putString("description", rawInvoice.description()?.into_inner())
         result.putBoolean("check_signature",  signedInv.check_signature())
         result.putBoolean("is_expired",  is_expired)

--- a/lib/src/ldk.ts
+++ b/lib/src/ldk.ts
@@ -1,4 +1,9 @@
-import { NativeModules, NativeEventEmitter, Platform } from 'react-native';
+import {
+	NativeModules,
+	NativeEventEmitter,
+	Platform,
+	EmitterSubscription,
+} from 'react-native';
 import { err, ok, Result } from './utils/result';
 import {
 	EEventTypes,
@@ -463,8 +468,11 @@ class LDK {
 	 * @param event
 	 * @param callback
 	 */
-	onEvent(event: EEventTypes, callback: (res: any) => void): void {
-		this.ldkEvent.addListener(event, callback);
+	onEvent(
+		event: EEventTypes,
+		callback: (res: any) => void,
+	): EmitterSubscription {
+		return this.ldkEvent.addListener(event, callback);
 	}
 
 	/**
@@ -532,71 +540,6 @@ class LDK {
 		} catch (e) {
 			return err(e);
 		}
-	}
-
-	/**
-	 * Callback passed though will get triggered for each LND log item
-	 * @param callback
-	 * @returns {string}
-	 */
-	addLogListener(callback: (log: string) => void): string {
-		const id = new Date().valueOf().toString() + Math.random().toString();
-		this.logListeners.push({ id, callback });
-		return id; // Developer needs to use this ID to unsubscribe later
-	}
-
-	/**
-	 * Removes a log listener once dev no longer wants to receive updates.
-	 * e.g. When a component has been unmounted
-	 * @param id
-	 */
-	removeLogListener(id: string): void {
-		let removeIndex = -1;
-		this.logListeners.forEach((listener, index) => {
-			if (listener.id === id) {
-				removeIndex = index;
-			}
-		});
-
-		if (removeIndex > -1) {
-			this.logListeners.splice(removeIndex, 1);
-		}
-	}
-
-	/**
-	 * Triggers every listener that has subscribed
-	 * @param log
-	 */
-	private processLogListeners(log: string): void {
-		if (!log) {
-			return;
-		}
-
-		if (__DEV__) {
-			console.log(log);
-		}
-
-		this.logListeners.forEach((listener) => listener.callback(log));
-	}
-
-	/**
-	 * Gets LND log file content
-	 * @param limit
-	 * @returns {Promise<Err<unknown> | Ok<string[]>>}
-	 */
-	async getLogFileContent(limit: number = 100): Promise<Result<string[]>> {
-		//TODO
-		// try {
-		// 	const content: string[] = await this.ldk.logFileContent(network, limit);
-		// 	return ok(content);
-		// } catch (e) {
-		// 	return err(e);
-		// }
-		if (__DEV__) {
-			console.log(limit);
-		}
-
-		return ok([]);
 	}
 }
 


### PR DESCRIPTION
- ldk.onEvent(...) will now return the `EmitterSubscription` and this can be used to unsubscribe at a later stage such as a useEffect cleanup when a component is unmounted.
- Removed old log subscription logic as it can be done with the above.

``` javascript
const sub = ldk.onEvent(EEventTypes.ldk_log, (log) => console.log(log));

//Done with subscription
sub.remove();
```