### PR TITLE
Zero sat invoice support

### DIFF
--- a/lib/android/src/main/java/com/reactnativeldk/Helpers.kt
+++ b/lib/android/src/main/java/com/reactnativeldk/Helpers.kt
@@ -37,7 +37,7 @@ val Invoice.asJson: WritableMap
         val signedInv = into_signed_raw()
         val rawInvoice = signedInv.raw_invoice()
 
-        result.putInt("amount_satoshis", (amount_milli_satoshis() as Option_u64Z.Some).some.toInt() / 1000)
+        if (amount_milli_satoshis() is Option_u64Z.Some) result.putInt("amount_satoshis", ((amount_milli_satoshis() as Option_u64Z.Some).some.toInt() / 1000)) else  result.putNull("amount_satoshis")
         result.putString("description", rawInvoice.description()?.into_inner())
         result.putBoolean("check_signature",  signedInv.check_signature())
         result.putBoolean("is_expired",  is_expired)

--- a/lib/android/src/main/java/com/reactnativeldk/LdkModule.kt
+++ b/lib/android/src/main/java/com/reactnativeldk/LdkModule.kt
@@ -58,6 +58,8 @@ enum class LdkErrors {
     decode_invoice_fail,
     init_invoice_payer,
     invoice_payment_fail_unknown,
+    invoice_payment_fail_must_specify_amount,
+    invoice_payment_fail_must_not_specify_amount,
     invoice_payment_fail_invoice,
     invoice_payment_fail_routing,
     invoice_payment_fail_sending,

--- a/lib/ios/Helpers.swift
+++ b/lib/ios/Helpers.swift
@@ -27,7 +27,7 @@ func handleReject(_ reject: RCTPromiseRejectBlock, _ ldkError: LdkErrors, _ erro
 extension Invoice {
     var asJson: Any {
         return [
-            "amount_satoshis": (amount_milli_satoshis().getValue() != nil ? amount_milli_satoshis().getValue()! / 1000 : nil),
+            "amount_satoshis": amount_milli_satoshis().getValue() != nil ? amount_milli_satoshis().getValue()! / 1000 : nil,
             "description": into_signed_raw().raw_invoice().description(),
             "check_signature": check_signature().isOk(),
             "is_expired": is_expired(),

--- a/lib/ios/Ldk.m
+++ b/lib/ios/Ldk.m
@@ -89,6 +89,7 @@ RCT_EXTERN_METHOD(decode:(NSString *)paymentRequest
                   resolve:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject)
 RCT_EXTERN_METHOD(pay:(NSString *)paymentRequest
+                  amountSats:(NSInteger *)amountSats
                   resolve:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject)
 RCT_EXTERN_METHOD(createPaymentRequest:(NSInteger *)amountSats

--- a/lib/ios/Ldk.swift
+++ b/lib/ios/Ldk.swift
@@ -501,7 +501,7 @@ class Ldk: NSObject {
         }
         
         let res = isZeroValueInvoice ?
-                    invoicePayer.pay_zero_value_invoice(invoice: invoice, amount_msats: UInt64(amountSats)) :
+                    invoicePayer.pay_zero_value_invoice(invoice: invoice, amount_msats: UInt64(amountSats * 1000)) :
                     invoicePayer.pay_invoice(invoice: invoice)
         if res.isOk() {
             return handleResolve(resolve, .invoice_payment_success)

--- a/lib/ios/Ldk.swift
+++ b/lib/ios/Ldk.swift
@@ -44,6 +44,8 @@ enum LdkErrors: String {
     case decode_invoice_fail = "decode_invoice_fail"
     case init_invoice_payer = "init_invoice_payer"
     case invoice_payment_fail_unknown = "invoice_payment_fail_unknown"
+    case invoice_payment_fail_must_specify_amount = "invoice_payment_fail_must_specify_amount"
+    case invoice_payment_fail_must_not_specify_amount = "invoice_payment_fail_must_not_specify_amount"
     case invoice_payment_fail_invoice = "invoice_payment_fail_invoice"
     case invoice_payment_fail_routing = "invoice_payment_fail_routing"
     case invoice_payment_fail_sending = "invoice_payment_fail_sending"
@@ -477,7 +479,7 @@ class Ldk: NSObject {
     }
 
     @objc
-    func pay(_ paymentRequest: NSString, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+    func pay(_ paymentRequest: NSString, amountSats: NSInteger, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
         guard let invoicePayer = invoicePayer else {
             return handleReject(reject, .init_invoice_payer)
         }
@@ -485,8 +487,22 @@ class Ldk: NSObject {
         guard let invoice = Invoice.from_str(s: String(paymentRequest)).getValue() else {
             return handleReject(reject, .decode_invoice_fail)
         }
-
-        let res = invoicePayer.pay_invoice(invoice: invoice)
+        
+        let isZeroValueInvoice = invoice.amount_milli_satoshis().getValue() == nil
+        
+        //If it's a zero invoice and we don't have an amount then don't proceed
+        guard !(isZeroValueInvoice && amountSats == 0) else {
+            return handleReject(reject, .invoice_payment_fail_must_specify_amount)
+        }
+        
+        //Amount was set but not allowed to set own amount
+        guard !(amountSats > 0 && !isZeroValueInvoice) else {
+            return handleReject(reject, .invoice_payment_fail_must_not_specify_amount)
+        }
+        
+        let res = isZeroValueInvoice ?
+                    invoicePayer.pay_zero_value_invoice(invoice: invoice, amount_msats: UInt64(amountSats)) :
+                    invoicePayer.pay_invoice(invoice: invoice)
         if res.isOk() {
             return handleResolve(resolve, .invoice_payment_success)
         }
@@ -541,11 +557,11 @@ class Ldk: NSObject {
             channelmanager: channelManager,
             keys_manager: keysManager.as_KeysInterface(),
             network: ldkCurrency,
-            amt_msat: Option_u64Z(value: UInt64(amountSats)),
+            amt_msat: amountSats == 0 ? Option_u64Z.none() : Option_u64Z(value: UInt64(amountSats)),
             description: String(description),
             invoice_expiry_delta_secs: UInt32(expiryDelta)
         )
-            
+        
         if res.isOk() {
             guard let invoice = res.getValue() else {
                 return handleReject(reject, .invoice_create_failed)

--- a/lib/src/ldk.ts
+++ b/lib/src/ldk.ts
@@ -407,7 +407,7 @@ class LDK {
 	}: TCreatePaymentReq): Promise<Result<TInvoice>> {
 		try {
 			const res = await NativeLDK.createPaymentRequest(
-				amountSats * 1000,
+				(amountSats || 0) * 1000,
 				description,
 				expiryDeltaSeconds,
 			);
@@ -449,18 +449,18 @@ class LDK {
 	 * @param paymentRequest
 	 * @returns {Promise<Err<unknown> | Ok<Ok<string> | Err<string>>>}
 	 */
-	async pay({ paymentRequest }: TPaymentReq): Promise<Result<string>> {
-		//TODO allow for setting amount if invoice amount is zero
+	async pay({
+		paymentRequest,
+		amountSats,
+	}: TPaymentReq): Promise<Result<string>> {
 		try {
-			const res = await NativeLDK.pay(paymentRequest);
+			const res = await NativeLDK.pay(paymentRequest, amountSats || 0);
 			return ok(res);
 		} catch (e) {
-			//TODO error can be drilled down in native code to provide better feedback and/or retry options.
 			return err(e);
 		}
 	}
 
-	//TODO pay_zero_value_invoice
 	//TODO pay_pubkey
 
 	/**

--- a/lib/src/utils/types.ts
+++ b/lib/src/utils/types.ts
@@ -208,10 +208,11 @@ export type TSpendOutputsReq = {
 
 export type TPaymentReq = {
 	paymentRequest: string;
+	amountSats?: number;
 };
 
 export type TCreatePaymentReq = {
-	amountSats: number;
+	amountSats?: number;
 	description: string;
 	expiryDeltaSeconds: number;
 };


### PR DESCRIPTION
- iOS and Android can create invoices with an unspecified amount
- iOS and Android can pay invoices while specifying amounts from sender

Create an invoice without passing `amountSats`
``` javascript
const createPaymentRequest = await ldk.createPaymentRequest({
  description: 'paymeplz',
  expiryDeltaSeconds: 999999,
});
```

Pay invoice with own amount if `amount_satoshis` is null
``` javascript
const decode = await ldk.decode({ paymentRequest });
if (!decode.amount_satoshis) {
  //Missing amount so we can specify our own
  const pay = await ldk.pay({
    paymentRequest,
    amountSats: 1234
  });
}
```
