### PR TITLE
Route failed debugging

### DIFF
--- a/lib/android/src/main/java/com/reactnativeldk/Helpers.kt
+++ b/lib/android/src/main/java/com/reactnativeldk/Helpers.kt
@@ -53,6 +53,26 @@ val Invoice.asJson: WritableMap
         result.putInt("currency", currency().ordinal)
         result.putString("to_str", signedInv.to_str())
 
+        val hints = Arguments.createArray()
+        route_hints().iterator().forEach { routeHint ->
+            val hops = Arguments.createArray()
+            routeHint._a.iterator().forEach { hop ->
+                hops.pushMap(hop.asJson)
+            }
+            hints.pushArray(hops)
+        }
+        result.putArray("route_hints", hints)
+
+        return result
+    }
+
+val RouteHintHop.asJson: WritableMap
+    get() {
+        val result = Arguments.createMap()
+
+        result.putHexString("src_node_id", _src_node_id)
+        result.putString("short_channel_id", _short_channel_id.toString())
+
         return result
     }
 

--- a/lib/ios/Helpers.swift
+++ b/lib/ios/Helpers.swift
@@ -41,7 +41,17 @@ extension Invoice {
             "timestamp": timestamp(),
             "features": Data(features().write()).hexEncodedString(),
             "currency": currency().rawValue,
-            "to_str": to_str()
+            "to_str": to_str(),
+            "route_hints": route_hints().map({ $0.get_a().map({ $0.asJson }) }),
+        ]
+    }
+}
+
+extension RouteHintHop {
+    var asJson: Any {
+        return [
+            "src_node_id": Data(get_src_node_id()).hexEncodedString(),
+            "short_channel_id": String(get_short_channel_id())
         ]
     }
 }

--- a/lib/src/ldk.ts
+++ b/lib/src/ldk.ts
@@ -456,10 +456,69 @@ class LDK {
 		paymentRequest,
 		amountSats,
 	}: TPaymentReq): Promise<Result<string>> {
+		//If no usable channels don't even attempt payment
+		const channelsRes = await this.listUsableChannels();
+		if (channelsRes.isOk() && channelsRes.value.length === 0) {
+			return err('No usable channels found');
+		}
+
 		try {
 			const res = await NativeLDK.pay(paymentRequest, amountSats || 0);
+
 			return ok(res);
 		} catch (e) {
+			let resultError = err(e);
+			//Add additional context to the error message for debugging if routing is failing.
+			if (resultError.code === 'invoice_payment_fail_routing') {
+				const decodedRes = await this.decode({ paymentRequest });
+				if (decodedRes.isErr()) {
+					//Return original payment error if we can't decode
+					return err(e);
+				}
+
+				const { route_hints, recover_payee_pub_key, amount_satoshis } =
+					decodedRes.value;
+
+				let useFullMessage = `${resultError.error.message}.`;
+
+				//Check route hints
+				if (route_hints.length === 0) {
+					useFullMessage = `${useFullMessage} No route hints found in payment request.`;
+				}
+
+				//Check if node is in our network graph
+				const graphRes = await this.networkGraphListNodes();
+				if (graphRes.isOk()) {
+					let nodeInNetworkGraph = false;
+					graphRes.value.forEach((node) => {
+						if (node === recover_payee_pub_key) {
+							nodeInNetworkGraph = true;
+						}
+					});
+
+					if (!nodeInNetworkGraph) {
+						useFullMessage = `${useFullMessage} Node not found in network graph.`;
+					}
+				}
+
+				//Check we have enough outgoing balance in a single usable channel
+				if (channelsRes.isOk()) {
+					let highestOutgoing = 0;
+					channelsRes.value.forEach(({ outbound_capacity_sat }) => {
+						if (outbound_capacity_sat > highestOutgoing) {
+							highestOutgoing = outbound_capacity_sat;
+						}
+					});
+
+					let amountToSendSats = amountSats || amount_satoshis || 0;
+					if (amountToSendSats > highestOutgoing) {
+						useFullMessage = `${useFullMessage} Not enough outgoing capacity.`;
+					}
+				}
+
+				return err(useFullMessage);
+			}
+
 			return err(e);
 		}
 	}

--- a/lib/src/utils/result.ts
+++ b/lib/src/utils/result.ts
@@ -13,7 +13,10 @@ export class Ok<T> {
 }
 
 export class Err<T> {
-	public constructor(public readonly error: Error) {
+	public constructor(
+		public readonly error: Error,
+		public readonly code: string = '',
+	) {
 		// Don't console log for unit tests or if we're not in dev mode
 		if (process.env.JEST_WORKER_ID === undefined && __DEV__) {
 			console.info(error);
@@ -39,8 +42,23 @@ export const ok = <T>(value: T): Ok<T> => new Ok(value);
  */
 export const err = <T>(error: Error | string | any): Err<T> => {
 	if (typeof error === 'string') {
-		return new Err(new Error(error));
+		return new Err(new Error(error), fallBackErrorCode(error));
 	}
 
-	return new Err(error);
+	return new Err(error, error.code || fallBackErrorCode(error.message));
+};
+
+/**
+ * Creates a slug type code for default error.code
+ * @param text
+ * @returns {string}
+ */
+const fallBackErrorCode = (text: string): string => {
+	if (!text) {
+		return '';
+	}
+	return text
+		.toLowerCase()
+		.replace(/[^\w ]+/g, '')
+		.replace(/ +/g, '-');
 };

--- a/lib/src/utils/types.ts
+++ b/lib/src/utils/types.ts
@@ -170,6 +170,14 @@ export type TInvoice = {
 	features?: string;
 	currency: number;
 	to_str: string; //Actual bolt11 invoice string
+	route_hints: RouteHints[];
+};
+
+export type RouteHints = RouteHintHop[];
+
+export type RouteHintHop = {
+	src_node_id: string;
+	short_channel_id: string;
 };
 
 export type TLogListener = {


### PR DESCRIPTION
- Decoded invoice now expose `route_hints`
- Result type has `code` param that is returned by the native code when rejecting. (Will add this to separate result lib when I replace it in this project)
- If ldk.pay() fails with `invoice_payment_fail_routing` then checks are done to better explain the likely reasons for the failed payment.
- - If invoice contained route hints. Related to [this issue](https://github.com/lightningnetwork/lnd/issues/6870). (some newer versions of LND can cause channels with LDK to not be updated so LDK won't include hints)
- - If the node we're trying to pay is in our network graph.
- - If usable channels have enough outgoing capacity to route that amount.

