### PR TITLE
Support newer react-native versions

### DIFF
--- a/lib/package.json
+++ b/lib/package.json
@@ -38,8 +38,8 @@
   "license": "MIT",
   "licenseFilename": "LICENSE",
   "peerDependencies": {
-    "react": "^16.8.1",
-    "react-native": ">=0.60.0-rc.0 <1.0.x"
+    "react": "*",
+    "react-native": "*"
   },
   "devDependencies": {
     "@react-native-community/eslint-config": "^2.0.0",


### PR DESCRIPTION
@coreyphillips thanks for your work on this module. I'm currently testing it and tried installing the npm package in a react-native `0.69.5` app and had to install using `npm i --force` since my peer dependency `react` was at `18.0.0`. This PR should fix that. Thanks :)