### PR TITLE
Claimable balances and misc fixes

### DIFF
--- a/example/App.tsx
+++ b/example/App.tsx
@@ -440,6 +440,18 @@ const App = (): ReactElement => {
 					/>
 
 					<Button
+						title={'Show claimable balances for closed/closing channels'}
+						onPress={async (): Promise<void> => {
+							const balances = await ldk.claimableBalances(true);
+							if (balances.isErr()) {
+								return setMessage(balances.error.message);
+							}
+
+							setMessage(JSON.stringify(balances.value));
+						}}
+					/>
+
+					<Button
 						title={'Show version'}
 						onPress={async (): Promise<void> => {
 							const ldkVersion = await ldk.version();

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -282,7 +282,7 @@ PODS:
   - React-jsinspector (0.68.2)
   - React-logger (0.68.2):
     - glog
-  - react-native-ldk (0.0.58):
+  - react-native-ldk (0.0.59):
     - React
   - react-native-randombytes (3.6.1):
     - React-Core
@@ -559,7 +559,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: b7b553412f2ec768fe6c8f27cd6bafdb9d8719e6
   React-jsinspector: c5989c77cb89ae6a69561095a61cce56a44ae8e8
   React-logger: a0833912d93b36b791b7a521672d8ee89107aff1
-  react-native-ldk: 8d185b68100be5cb15e060aa78e3a9808295fd33
+  react-native-ldk: d8da94aa7fe37cc9bf034502a44135d196e9a22c
   react-native-randombytes: 421f1c7d48c0af8dbcd471b0324393ebf8fe7846
   react-native-tcp-socket: c1b7297619616b4c9caae6889bcb0aba78086989
   React-perflogger: a18b4f0bd933b8b24ecf9f3c54f9bf65180f3fe6

--- a/lib/android/src/main/java/com/reactnativeldk/Helpers.kt
+++ b/lib/android/src/main/java/com/reactnativeldk/Helpers.kt
@@ -91,7 +91,7 @@ val ChannelDetails.asJson: WritableMap
         result.putHexString("funding_txo", _funding_txo?.write())
         result.putHexString("channel_type", _channel_type?.write())
         result.putInt("user_channel_id", _user_channel_id.toInt())
-        result.putInt("get_confirmations_required", (_confirmations_required as Option_u32Z.Some).some)
+        result.putInt("confirmations_required", (_confirmations_required as Option_u32Z.Some).some)
         (_short_channel_id as? Option_u64Z.Some)?.some?.toInt()
             ?.let { result.putInt("short_channel_id", it) } //Optional number
         (_inbound_scid_alias as? Option_u64Z.Some)?.some?.toInt()

--- a/lib/android/src/main/java/com/reactnativeldk/Helpers.kt
+++ b/lib/android/src/main/java/com/reactnativeldk/Helpers.kt
@@ -88,7 +88,7 @@ val ChannelDetails.asJson: WritableMap
         result.putBoolean("is_outbound", _is_outbound)
         result.putInt("balance_sat", _balance_msat.toInt() / 1000)
         result.putHexString("counterparty_node_id", _counterparty._node_id)
-        result.putHexString("funding_txo", _funding_txo?.write())
+        result.putHexString("funding_txid", _funding_txo?._txid?.reversed()?.toByteArray())
         result.putHexString("channel_type", _channel_type?.write())
         result.putInt("user_channel_id", _user_channel_id.toInt())
         result.putInt("confirmations_required", (_confirmations_required as Option_u32Z.Some).some)

--- a/lib/android/src/main/java/com/reactnativeldk/LdkModule.kt
+++ b/lib/android/src/main/java/com/reactnativeldk/LdkModule.kt
@@ -16,7 +16,6 @@ import org.ldk.structs.Result_InvoiceSignOrCreationErrorZ.Result_InvoiceSignOrCr
 import org.ldk.structs.Result_ProbabilisticScorerDecodeErrorZ.Result_ProbabilisticScorerDecodeErrorZ_OK
 import java.io.File
 import java.net.InetSocketAddress
-import java.nio.channels.Channel
 import java.nio.file.Files
 import java.nio.file.Paths
 

--- a/lib/android/src/main/java/com/reactnativeldk/LdkModule.kt
+++ b/lib/android/src/main/java/com/reactnativeldk/LdkModule.kt
@@ -618,7 +618,7 @@ class LdkModule(reactContext: ReactApplicationContext) : ReactContextBaseJavaMod
             channelManager,
             keysManager!!.as_KeysInterface(),
             ldkCurrency,
-            if (amountSats == 0.0) Option_u64Z.none() else Option_u64Z.some(amountSats.toLong()),
+            if (amountSats == 0.0) Option_u64Z.none() else Option_u64Z.some((amountSats * 1000).toLong()),
             description,
             expiryDelta.toInt()
         );

--- a/lib/android/src/main/java/com/reactnativeldk/LdkModule.kt
+++ b/lib/android/src/main/java/com/reactnativeldk/LdkModule.kt
@@ -16,6 +16,7 @@ import org.ldk.structs.Result_InvoiceSignOrCreationErrorZ.Result_InvoiceSignOrCr
 import org.ldk.structs.Result_ProbabilisticScorerDecodeErrorZ.Result_ProbabilisticScorerDecodeErrorZ_OK
 import java.io.File
 import java.net.InetSocketAddress
+import java.nio.channels.Channel
 import java.nio.file.Files
 import java.nio.file.Paths
 
@@ -732,6 +733,52 @@ class LdkModule(reactContext: ReactApplicationContext) : ReactContextBaseJavaMod
         val graph = networkGraph?.read_only() ?: return handleReject(promise, LdkErrors.init_network_graph)
 
         promise.resolve(graph.channel(shortChannelId.toLong())?.asJson)
+    }
+
+    @ReactMethod
+    fun claimableBalances(ignoreOpenChannels: Boolean, promise: Promise) {
+        val channelManager = channelManager ?: return handleReject(promise, LdkErrors.init_channel_manager)
+        val chainMonitor = chainMonitor ?: return handleReject(promise, LdkErrors.init_chain_monitor)
+
+        val ignoredChannels = if (ignoreOpenChannels)
+            channelManager.list_channels() else
+            arrayOf<ChannelDetails>()
+
+        val result = Arguments.createArray()
+
+        chainMonitor.get_claimable_balances(ignoredChannels).iterator().forEach { balance ->
+            val map = Arguments.createMap()
+            //Defaults if all castings for balance fail
+            map.putInt("claimable_amount_satoshis", 0)
+            map.putString("type", "Unknown")
+
+            (balance as? Balance.ClaimableAwaitingConfirmations)?.let { claimableAwaitingConfirmations ->
+                map.putInt("claimable_amount_satoshis", claimableAwaitingConfirmations.claimable_amount_satoshis.toInt())
+                map.putInt("confirmation_height", claimableAwaitingConfirmations.confirmation_height)
+                map.putString("type", "ClaimableAwaitingConfirmations")
+            }
+
+            (balance as? Balance.ClaimableOnChannelClose)?.let { claimableOnChannelClose ->
+                map.putInt("claimable_amount_satoshis", claimableOnChannelClose.claimable_amount_satoshis.toInt())
+                map.putString("type", "ClaimableOnChannelClose")
+            }
+
+            (balance as? Balance.ContentiousClaimable)?.let { contentiousClaimable ->
+                map.putInt("claimable_amount_satoshis", contentiousClaimable.claimable_amount_satoshis.toInt())
+                map.putInt("timeout_height", contentiousClaimable.timeout_height)
+                map.putString("type", "ContentiousClaimable")
+            }
+
+            (balance as? Balance.MaybeClaimableHTLCAwaitingTimeout)?.let { maybeClaimableHTLCAwaitingTimeout ->
+                map.putInt("claimable_amount_satoshis", maybeClaimableHTLCAwaitingTimeout.claimable_amount_satoshis.toInt())
+                map.putInt("claimable_height", maybeClaimableHTLCAwaitingTimeout.claimable_height)
+                map.putString("type", "MaybeClaimableHTLCAwaitingTimeout")
+            }
+
+            result.pushMap(map)
+        }
+
+        promise.resolve(result)
     }
 
     //MARK: Misc methods

--- a/lib/ios/Helpers.swift
+++ b/lib/ios/Helpers.swift
@@ -67,7 +67,7 @@ extension ChannelDetails {
             "is_outbound": get_is_outbound(),
             "balance_sat": get_balance_msat() / 1000,
             "counterparty_node_id": Data(get_counterparty().get_node_id()).hexEncodedString(),
-            "funding_txo": Data(get_funding_txo()?.write() ?? []).hexEncodedString(),
+            "funding_txid": Data(get_funding_txo()?.get_txid().reversed() ?? []).hexEncodedString(),
             "channel_type": Data(get_channel_type().write()).hexEncodedString(),
             "user_channel_id": get_user_channel_id(), //Number
             "confirmations_required": get_confirmations_required().getValue() as Any, // Optional number

--- a/lib/ios/Ldk.m
+++ b/lib/ios/Ldk.m
@@ -93,6 +93,9 @@ RCT_EXTERN_METHOD(networkGraphChannel:(NSString *)shortChannelId
 RCT_EXTERN_METHOD(networkGraphNode:(NSString *)nodeId
                   resolve:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject)
+RCT_EXTERN_METHOD(claimableBalances:(BOOL *)ignoreOpenChannels
+                  resolve:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject)
 
 //MARK: Payments
 RCT_EXTERN_METHOD(decode:(NSString *)paymentRequest

--- a/lib/ios/Ldk.swift
+++ b/lib/ios/Ldk.swift
@@ -758,6 +758,59 @@ class Ldk: NSObject {
         return resolve(networkGraph.channel(short_channel_id: UInt64(shortChannelId as String)!).asJson)
     }
     
+    @objc
+    func claimableBalances(_ ignoreOpenChannels: Bool, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+        guard let channelManager = channelManager else {
+            return handleReject(reject, .init_channel_manager)
+        }
+        
+        guard let chainMonitor = chainMonitor else {
+            return handleReject(reject, .init_chain_monitor)
+        }
+        
+        let ignoredChannels = ignoreOpenChannels ? [] : channelManager.list_channels()
+        
+        let result: [Any] = chainMonitor.get_claimable_balances(ignored_channels: ignoredChannels).map { balance in
+            switch balance.getValueType() {
+            case .ClaimableAwaitingConfirmations:
+                let b = balance.getValueAsClaimableAwaitingConfirmations()!
+                return [
+                    "claimable_amount_satoshis": b.getClaimable_amount_satoshis(),
+                    "confirmation_height": b.getConfirmation_height(),
+                    "type": "ClaimableAwaitingConfirmations"
+                ]
+            case .ClaimableOnChannelClose:
+                let b = balance.getValueAsClaimableOnChannelClose()!
+                return [
+                    "claimable_amount_satoshis": b.getClaimable_amount_satoshis(),
+                    "type": "ClaimableOnChannelClose"
+                ]
+            case .ContentiousClaimable:
+                let b = balance.getValueAsContentiousClaimable()!
+                return [
+                    "claimable_amount_satoshis": b.getClaimable_amount_satoshis(),
+                    "timeout_height": b.getTimeout_height(),
+                    "type": "ContentiousClaimable"
+                ]
+            case .MaybeClaimableHTLCAwaitingTimeout:
+                let b = balance.getValueAsMaybeClaimableHTLCAwaitingTimeout()!
+                return [
+                    "claimable_amount_satoshis": b.getClaimable_amount_satoshis(),
+                    "claimable_height": b.getClaimable_height(),
+                    "type": "MaybeClaimableHTLCAwaitingTimeout"
+                ]
+            case .none:
+                LdkEventEmitter.shared.send(withEvent: .native_log, body: "Unknown claimable balance type in claimableBalances()")
+            case .some(_):
+                LdkEventEmitter.shared.send(withEvent: .native_log, body: "Unknown balance type type in claimableBalances()")
+            }
+        
+            return ["claimable_amount_satoshis": 0]
+        }
+        
+        return resolve(result)
+    }
+    
     //MARK: Misc functions
     @objc
     func writeToFile(_ fileName: NSString, path: NSString, content: NSString, format: NSString, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {

--- a/lib/ios/Ldk.swift
+++ b/lib/ios/Ldk.swift
@@ -633,7 +633,7 @@ class Ldk: NSObject {
             channelmanager: channelManager,
             keys_manager: keysManager.as_KeysInterface(),
             network: ldkCurrency,
-            amt_msat: amountSats == 0 ? Option_u64Z.none() : Option_u64Z(value: UInt64(amountSats)),
+            amt_msat: amountSats == 0 ? Option_u64Z.none() : Option_u64Z(value: UInt64(amountSats * 1000)),
             description: String(description),
             invoice_expiry_delta_secs: UInt32(expiryDelta)
         )

--- a/lib/ios/Ldk.swift
+++ b/lib/ios/Ldk.swift
@@ -805,7 +805,7 @@ class Ldk: NSObject {
                 LdkEventEmitter.shared.send(withEvent: .native_log, body: "Unknown balance type type in claimableBalances()")
             }
         
-            return ["claimable_amount_satoshis": 0]
+            return ["claimable_amount_satoshis": 0, "type": "Unknown"]
         }
         
         return resolve(result)

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@synonymdev/react-native-ldk",
   "title": "React Native LDK",
-  "version": "0.0.58",
+  "version": "0.0.59",
   "description": "React Native wrapper for LDK",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/lib/src/ldk.ts
+++ b/lib/src/ldk.ts
@@ -28,6 +28,7 @@ import {
 	TFileReadRes,
 	TFileReadReq,
 	TFileWriteReq,
+	TClaimableBalance,
 } from './utils/types';
 
 const LINKING_ERROR =
@@ -739,6 +740,23 @@ class LDK {
 			}
 
 			return ok(channels);
+		} catch (e) {
+			return err(e);
+		}
+	}
+
+	/**
+	 * Fetches a list of all channels LDK has ever had. Use ignoreOpenChannels to get
+	 * pending balances for channels no longer included in list_channels (closed/closing channels).
+	 * @param ignoreOpenChannels
+	 * @returns {Promise<Ok<Ok<TClaimableBalance[]> | Err<TClaimableBalance[]>> | Err<unknown>>}
+	 */
+	async claimableBalances(
+		ignoreOpenChannels: boolean,
+	): Promise<Result<TClaimableBalance[]>> {
+		try {
+			const res = await NativeLDK.claimableBalances(ignoreOpenChannels);
+			return ok(res);
 		} catch (e) {
 			return err(e);
 		}

--- a/lib/src/ldk.ts
+++ b/lib/src/ldk.ts
@@ -432,7 +432,7 @@ class LDK {
 		//TODO confirm we have enough incoming capacity
 		try {
 			const res = await NativeLDK.createPaymentRequest(
-				(amountSats || 0) * 1000,
+				amountSats || 0,
 				description,
 				expiryDeltaSeconds,
 			);

--- a/lib/src/ldk.ts
+++ b/lib/src/ldk.ts
@@ -748,6 +748,7 @@ class LDK {
 	/**
 	 * Fetches a list of all channels LDK has ever had. Use ignoreOpenChannels to get
 	 * pending balances for channels no longer included in list_channels (closed/closing channels).
+	 * https://docs.rs/lightning/latest/lightning/chain/chainmonitor/struct.ChainMonitor.html#method.get_claimable_balances
 	 * @param ignoreOpenChannels
 	 * @returns {Promise<Ok<Ok<TClaimableBalance[]> | Err<TClaimableBalance[]>> | Err<unknown>>}
 	 */

--- a/lib/src/lightning-manager.ts
+++ b/lib/src/lightning-manager.ts
@@ -654,10 +654,6 @@ class LightningManager {
 				return err(channelManagerRes.error);
 			}
 
-			if (channelManagerRes.isOk()) {
-				channelManagerRes.value;
-			}
-
 			if (!overwrite && accountBackup.data?.timestamp <= timestamp) {
 				const msg =
 					accountBackup.data?.timestamp < timestamp
@@ -812,6 +808,7 @@ class LightningManager {
 					timestamp: Date.now(),
 				},
 				package_version: require('../package.json').version,
+				network: this.network,
 			};
 			return ok(accountBackup);
 		} catch (e) {

--- a/lib/src/utils/types.ts
+++ b/lib/src/utils/types.ts
@@ -294,7 +294,8 @@ export type TClaimableBalance = {
 		| 'ClaimableAwaitingConfirmations'
 		| 'ClaimableOnChannelClose'
 		| 'ContentiousClaimable'
-		| 'MaybeClaimableHTLCAwaitingTimeout';
+		| 'MaybeClaimableHTLCAwaitingTimeout'
+		| 'Unknown';
 	confirmation_height?: number;
 	timeout_height?: number;
 	claimable_height?: number;

--- a/lib/src/utils/types.ts
+++ b/lib/src/utils/types.ts
@@ -351,6 +351,7 @@ export type TLdkData = {
 export type TAccountBackup = {
 	account: TAccount;
 	package_version: string;
+	network: ENetworks;
 	data: TLdkData;
 };
 

--- a/lib/src/utils/types.ts
+++ b/lib/src/utils/types.ts
@@ -288,6 +288,18 @@ export type TTransactionData = {
 	vout: TVout[];
 };
 
+export type TClaimableBalance = {
+	claimable_amount_satoshis: number;
+	type:
+		| 'ClaimableAwaitingConfirmations'
+		| 'ClaimableOnChannelClose'
+		| 'ContentiousClaimable'
+		| 'MaybeClaimableHTLCAwaitingTimeout';
+	confirmation_height?: number;
+	timeout_height?: number;
+	claimable_height?: number;
+};
+
 export type TFileWriteReq = {
 	fileName: string;
 	path?: string;


### PR DESCRIPTION
- Exposes claimable balances which is an array of balances that includes `claimable_amount_satoshis` and the balance's `confirmation_height`/ `claimable_height`. Possible to include/exclude current open channels so it can just be used to show user's their pending and not yet spendable on chain balance.
- Fixed invalid `funding_txo`. Also now renamed to `funding_txid` to be more clear.
- `amountSats` unit fix for code clarity. Converting to milli sats in native code instead of JS.
- Adding network to backup data structure.
