### PR TITLE
Subscribe To & Timeout Payments

### DIFF
--- a/example/App.tsx
+++ b/example/App.tsx
@@ -413,15 +413,16 @@ const App = (): ReactElement => {
 									{
 										text: 'Pay',
 										onPress: async (): Promise<void> => {
-											const pay = await ldk.pay({
+											const pay = await lm.payWithTimeout({
 												paymentRequest,
 												amountSats: amount_satoshis ? undefined : ownAmountSats,
+												timeout: 20000,
 											});
 											if (pay.isErr()) {
 												return setMessage(pay.error.message);
 											}
 
-											setMessage(pay.value);
+											setMessage(pay.value.payment_id);
 										},
 									},
 								],

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -282,7 +282,7 @@ PODS:
   - React-jsinspector (0.68.2)
   - React-logger (0.68.2):
     - glog
-  - react-native-ldk (0.0.59):
+  - react-native-ldk (0.0.60):
     - React
   - react-native-randombytes (3.6.1):
     - React-Core
@@ -559,7 +559,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: b7b553412f2ec768fe6c8f27cd6bafdb9d8719e6
   React-jsinspector: c5989c77cb89ae6a69561095a61cce56a44ae8e8
   React-logger: a0833912d93b36b791b7a521672d8ee89107aff1
-  react-native-ldk: d8da94aa7fe37cc9bf034502a44135d196e9a22c
+  react-native-ldk: 9dd3029e993b1740055e1033f9670582b9100fcc
   react-native-randombytes: 421f1c7d48c0af8dbcd471b0324393ebf8fe7846
   react-native-tcp-socket: c1b7297619616b4c9caae6889bcb0aba78086989
   React-perflogger: a18b4f0bd933b8b24ecf9f3c54f9bf65180f3fe6

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@synonymdev/react-native-ldk",
   "title": "React Native LDK",
-  "version": "0.0.59",
+  "version": "0.0.60",
   "description": "React Native wrapper for LDK",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/lib/src/utils/helpers.ts
+++ b/lib/src/utils/helpers.ts
@@ -214,3 +214,19 @@ export const parseData = (data: string, fallback: any): any => {
 export const appendPath = (path1: string, path2: string): string => {
 	return `${path1}${path1.slice(-1) === '/' ? '' : '/'}${path2}`;
 };
+
+export const promiseTimeout = <T>(
+	ms: number,
+	promise: Promise<any>,
+): Promise<T> => {
+	let id: NodeJS.Timeout | undefined;
+	let timeout = new Promise((resolve) => {
+		id = setTimeout(() => {
+			resolve(err('Timed Out.'));
+		}, ms);
+	});
+	return Promise.race([promise, timeout]).then((result) => {
+		clearTimeout(id);
+		return result;
+	});
+};

--- a/lib/src/utils/types.ts
+++ b/lib/src/utils/types.ts
@@ -243,6 +243,10 @@ export type TPaymentReq = {
 	amountSats?: number;
 };
 
+export type TPaymentTimeoutReq = TPaymentReq & {
+	timeout?: number; //ms
+};
+
 export type TCreatePaymentReq = {
 	amountSats?: number;
 	description: string;


### PR DESCRIPTION
This PR:
- Adds `payWithTimeout` helper method to `lightning-manager.ts` to properly subscribe to and listen for outgoing payment events.
- Updates example app accordingly.