### PR TITLE
iOS rapid gossip sync

### DIFF
--- a/lib/android/src/main/java/com/reactnativeldk/LdkModule.kt
+++ b/lib/android/src/main/java/com/reactnativeldk/LdkModule.kt
@@ -257,7 +257,7 @@ class LdkModule(reactContext: ReactApplicationContext) : ReactContextBaseJavaMod
     }
 
     @ReactMethod
-    fun initNetworkGraph(genesisHash: String, promise: Promise) {
+    fun initNetworkGraph(genesisHash: String, rapidGossipSyncUrl: String, promise: Promise) {
         if (networkGraph !== null) {
             return handleReject(promise, LdkErrors.already_init)
         }

--- a/lib/ios/Helpers.swift
+++ b/lib/ios/Helpers.swift
@@ -214,7 +214,7 @@ extension RapidGossipSync {
         }
 
         let url = URL(string: "\(downloadUrl)\(timestamp)")!
-        
+
         let task = url.downloadTask(destination: destinationFile) { error in
             if let error = error {
                 return completion(error)
@@ -225,7 +225,7 @@ extension RapidGossipSync {
                 var errorMessage = "Failed to update network graph."
                 switch res.getError()?.getValueType() {
                 case .LightningError:
-                    errorMessage = "Rapid sync error. \(res.getError()!.getValueAsLightningError()!.get_err())"
+                    errorMessage = "Rapid sync error. \(res.getError()!.getValueAsLightningError()!.get_err())" //Couldn't find channel for update.
                     break;
                 case .DecodeError:
                     errorMessage = "Rapid sync error. IO error: \(res.getError()!.getValueAsDecodeError()?.getValueAsIo()?.rawValue ?? 0)"

--- a/lib/ios/Helpers.swift
+++ b/lib/ios/Helpers.swift
@@ -170,3 +170,80 @@ extension LdkEventEmitter {
 }
 
 extension String: Error {}
+
+extension URL {
+    func downloadTask(destination: URL, completion: @escaping (Error?) -> Void) -> URLSessionDataTask? {
+        if FileManager().fileExists(atPath: destination.path) {
+            completion(NSError(domain: "", code: 500, userInfo: [ NSLocalizedDescriptionKey: "File already exists"]))
+            return nil
+        }
+      
+        let session = URLSession(configuration: URLSessionConfiguration.default, delegate: nil, delegateQueue: nil)
+        var request = URLRequest(url: self)
+        request.httpMethod = "GET"
+        return session.dataTask(with: request, completionHandler: { data, response, error in
+            guard error == nil else {
+                return completion(error)
+            }
+            
+            guard let response = response as? HTTPURLResponse, let data = data else {
+                return completion(NSError(domain: "", code: 500, userInfo: [ NSLocalizedDescriptionKey: "Failed to get HTTP response"]))
+            }
+            
+            guard response.statusCode == 200 else {
+                return completion(NSError(domain: "", code: response.statusCode, userInfo: [ NSLocalizedDescriptionKey: "Download failed from \(self) with status (\(response.statusCode))"]))
+            }
+            
+            do {
+                try data.write(to: destination, options: Data.WritingOptions.atomic)
+                return completion(nil)
+            } catch {
+               return completion(error)
+            }
+        })
+    }
+}
+
+extension RapidGossipSync {
+    func downloadAndUpdateGraph(downloadUrl: String, tempStoragePath: URL, timestamp: UInt32, completion: @escaping (Error?) -> Void) {
+        let destinationFile = tempStoragePath.appendingPathComponent("\(timestamp).bin")
+      
+        //Cleanup old one
+        if FileManager().fileExists(atPath: destinationFile.path) {
+            try? FileManager().removeItem(atPath: destinationFile.path)
+        }
+
+        let url = URL(string: "\(downloadUrl)\(timestamp)")!
+        
+        let task = url.downloadTask(destination: destinationFile) { error in
+            if let error = error {
+                return completion(error)
+            }
+                        
+            let res = self.update_network_graph(update_data: [UInt8](try! Data(contentsOf: destinationFile)))
+            guard res.isOk() else {
+                var errorMessage = "Failed to update network graph."
+                switch res.getError()?.getValueType() {
+                case .LightningError:
+                    errorMessage = "Rapid sync error. \(res.getError()!.getValueAsLightningError()!.get_err())"
+                    break;
+                case .DecodeError:
+                    errorMessage = "Rapid sync error. IO error: \(res.getError()!.getValueAsDecodeError()?.getValueAsIo()?.rawValue ?? 0)"
+                    break;
+                default:
+                    errorMessage = "Unknown rapid sync error."
+                    break;
+                }
+
+                completion(NSError(domain: "", code: 500, userInfo: [ NSLocalizedDescriptionKey: errorMessage]))
+                try? FileManager().removeItem(atPath: destinationFile.path)
+                return
+            }
+            
+            completion(nil)
+            try? FileManager().removeItem(atPath: destinationFile.path)
+        }
+        
+        task?.resume()
+    }
+}

--- a/lib/ios/Ldk.m
+++ b/lib/ios/Ldk.m
@@ -22,6 +22,7 @@ RCT_EXTERN_METHOD(initConfig:(BOOL *)acceptInboundChannels
                   resolve:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject)
 RCT_EXTERN_METHOD(initNetworkGraph:(NSString *)genesisHash
+                  rapidGossipSyncUrl:(NSString *)rapidGossipSyncUrl
                   resolve:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject)
 RCT_EXTERN_METHOD(initChannelManager:(NSString *)network

--- a/lib/ios/Ldk.swift
+++ b/lib/ios/Ldk.swift
@@ -23,6 +23,7 @@ enum EventTypes: String, CaseIterable {
     case channel_manager_payment_claimed = "channel_manager_payment_claimed"
     case emergency_force_close_channel = "emergency_force_close_channel"
     case new_channel = "new_channel"
+    case network_graph_ready = "network_graph_ready"
 }
 //*****************************************************************
 
@@ -61,6 +62,8 @@ enum LdkErrors: String {
     case write_fail = "write_fail"
     case read_fail = "read_fail"
     case file_does_not_exist = "file_does_not_exist"
+    case init_network_graph_fail = "init_network_graph_fail"
+    case data_too_large_for_rn = "data_too_large_for_rn"
 }
 
 enum LdkCallbackResponses: String {
@@ -108,6 +111,7 @@ class Ldk: NSObject {
     var channelManager: ChannelManager?
     var userConfig: UserConfig?
     var networkGraph: NetworkGraph?
+    var rapidGossipSync: RapidGossipSync?
     var peerManager: PeerManager?
     var peerHandler: TCPPeerHandler?
     var channelManagerConstructor: ChannelManagerConstructor?
@@ -233,7 +237,7 @@ class Ldk: NSObject {
     }
 
     @objc
-    func initNetworkGraph(_ genesisHash: NSString, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+    func initNetworkGraph(_ genesisHash: NSString, rapidGossipSyncUrl: NSString, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
         guard networkGraph == nil else {
             return handleReject(reject, .already_init)
         }
@@ -246,14 +250,60 @@ class Ldk: NSObject {
             let read = NetworkGraph.read(ser: [UInt8](try Data(contentsOf: accountStoragePath.appendingPathComponent(LdkFileNames.network_graph.rawValue).standardizedFileURL)), arg: logger)
             if read.isOk() {
                 networkGraph = read.getValue()
+                LdkEventEmitter.shared.send(withEvent: .native_log, body: "Loaded network graph from file")
+
             }
         } catch {
+            networkGraph = NetworkGraph(genesis_hash: String(genesisHash).hexaBytes, logger: logger)
             LdkEventEmitter.shared.send(withEvent: .native_log, body: "Failed to load cached network graph from disk. Will sync from scratch. \(error.localizedDescription)")
         }
         
-        if networkGraph == nil {
-            LdkEventEmitter.shared.send(withEvent: .native_log, body: "Failed to load cached network graph from disk. Will sync from scratch.")
-            networkGraph = NetworkGraph(genesis_hash: String(genesisHash).hexaBytes, logger: logger)
+        
+        //Download url passed, enable rapid gossip sync
+        if rapidGossipSyncUrl != "" {
+            do {
+                let rapidGossipSyncStoragePath = accountStoragePath.appendingPathComponent("rapid_gossip_sync")
+                if !FileManager().fileExists(atPath: rapidGossipSyncStoragePath.path) {
+                    try FileManager.default.createDirectory(atPath: rapidGossipSyncStoragePath.path, withIntermediateDirectories: true, attributes: nil)
+                }
+
+                rapidGossipSync = RapidGossipSync(network_graph: networkGraph!)
+                
+                print("***rapidGossipSync: \(rapidGossipSync?.is_initial_sync_complete())")
+                
+                let timestamp = networkGraph?.get_last_rapid_gossip_sync_timestamp().getValue() ?? 0
+                //TODO check if it's been more than 24 hours before trying again
+                
+                rapidGossipSync!.downloadAndUpdateGraph(downloadUrl: String(rapidGossipSyncUrl), tempStoragePath: rapidGossipSyncStoragePath, timestamp: timestamp) { [weak self] error in
+                    guard let self = self else { return }
+                    
+                    LdkEventEmitter.shared.send(withEvent: .native_log, body: "Rapid gossip sync file downloaded.")
+                    
+                    try? FileManager.default.createDirectory(atPath: rapidGossipSyncStoragePath.path, withIntermediateDirectories: true, attributes: nil)
+                    if let error = error {
+                        return LdkEventEmitter.shared.send(withEvent: .native_log, body: "Failed to download rapid sync file. \(error.localizedDescription).")
+                    }
+
+                    LdkEventEmitter.shared.send(withEvent: .native_log, body: "Rapid gossip sync completed.")
+
+                    guard let graph = self.networkGraph?.read_only() else {
+                        return LdkEventEmitter.shared.send(withEvent: .native_log, body: "Failed to use network graph.")
+                    }
+                    
+                    let persistRes = self.channelManagerPersister.persist_graph(network_graph: self.networkGraph!)
+                    print("persistRes ERROR  \(persistRes.getError())")
+                    
+                    LdkEventEmitter.shared.send(
+                        withEvent: .network_graph_ready,
+                        body: [
+                            "channel_count": graph.list_channels().count,
+                            "node_count": graph.list_nodes().count,
+                        ]
+                    )
+                }
+            } catch {
+                return handleReject(reject, .init_network_graph_fail, error)
+            }
         }
         
         return handleResolve(resolve, .network_graph_init_success)
@@ -303,6 +353,8 @@ class Ldk: NSObject {
             return handleReject(reject, .invalid_network)
         }
         
+        let enableP2PGossip = rapidGossipSync == nil
+        
         let storedChannelManager = try? Data(contentsOf: accountStoragePath.appendingPathComponent(LdkFileNames.channel_manager.rawValue).standardizedFileURL)
         
         do {
@@ -326,7 +378,7 @@ class Ldk: NSObject {
                     net_graph_serialized: networkGraph.write(),
                     tx_broadcaster: broadcaster,
                     logger: logger,
-                    enableP2PGossip: true
+                    enableP2PGossip: enableP2PGossip
                 )
             } else {
                 //New node
@@ -342,7 +394,7 @@ class Ldk: NSObject {
                     net_graph: networkGraph,
                     tx_broadcaster: broadcaster,
                     logger: logger,
-                    enableP2PGossip: true
+                    enableP2PGossip: enableP2PGossip
                 )
             }
         } catch {
@@ -350,7 +402,7 @@ class Ldk: NSObject {
         }
 
         channelManager = channelManagerConstructor!.channelManager
-        self.networkGraph = channelManagerConstructor!.net_graph
+//        self.networkGraph = channelManagerConstructor!.net_graph
                 
         //Scorer setup
         let scoringParams = ProbabilisticScoringParameters()
@@ -721,7 +773,7 @@ class Ldk: NSObject {
         guard let peerManager = peerManager else {
             return handleReject(reject, .init_peer_manager)
         }
-
+        
         return resolve(peerManager.get_peer_node_ids().map { Data($0).hexEncodedString() })
     }
 
@@ -749,6 +801,11 @@ class Ldk: NSObject {
             return handleReject(reject, .init_network_graph)
         }
                 
+        let total = networkGraph.list_nodes().count
+        if total > 100 {
+            return handleReject(reject, .data_too_large_for_rn, nil, "Too many nodes to return (\(total))")
+        }
+                
         return resolve(networkGraph.list_nodes().map { Data($0.as_slice()).hexEncodedString() })
     }
     
@@ -765,6 +822,11 @@ class Ldk: NSObject {
     func networkGraphListChannels(_ resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
         guard let networkGraph = networkGraph?.read_only() else {
             return handleReject(reject, .init_network_graph)
+        }
+        
+        let total = networkGraph.list_channels().count
+        if total > 100 {
+            return handleReject(reject, .data_too_large_for_rn, nil, "Too many channels to return (\(total))")
         }
         
         return resolve(networkGraph.list_channels().map { String($0) })

--- a/lib/src/ldk.ts
+++ b/lib/src/ldk.ts
@@ -119,15 +119,21 @@ class LDK {
 
 	/**
 	 * Inits the network graph from previous cache or syncs from scratch using genesis block hash.
+	 * By passing in rapidGossipSyncUrl p2p gossip sync will be disabled in favor out rapid gossip sync.
+	 * For local regtest p2p works fine but for mainnet it is better to enable rapid gossip sync.
 	 * https://docs.rs/lightning/latest/lightning/routing/network_graph/struct.NetworkGraph.html
 	 * @param genesisHash
 	 * @returns {Promise<Err<unknown> | Ok<Ok<string> | Err<string>>>}
 	 */
 	async initNetworkGraph({
 		genesisHash,
+		rapidGossipSyncUrl,
 	}: TInitNetworkGraphReq): Promise<Result<string>> {
 		try {
-			const res = await NativeLDK.initNetworkGraph(genesisHash);
+			const res = await NativeLDK.initNetworkGraph(
+				genesisHash,
+				rapidGossipSyncUrl ?? '',
+			);
 			return ok(res);
 		} catch (e) {
 			return err(e);

--- a/lib/src/lightning-manager.ts
+++ b/lib/src/lightning-manager.ts
@@ -43,6 +43,7 @@ import {
 	TPaymentReq,
 	TPaymentTimeoutReq,
 	TLdkPaymentIds,
+	TNetworkGraphReady,
 } from './utils/types';
 import {
 	appendPath,
@@ -180,6 +181,10 @@ class LightningManager {
 		ldk.onEvent(
 			EEventTypes.emergency_force_close_channel,
 			this.onEmergencyForceCloseChannel.bind(this),
+		);
+		ldk.onEvent(
+			EEventTypes.network_graph_ready,
+			this.onNetworkGraphReady.bind(this),
 		);
 	}
 
@@ -364,6 +369,7 @@ class LightningManager {
 		// Step 11: Optional: Initialize the NetGraphMsgHandler
 		const networkGraphRes = await ldk.initNetworkGraph({
 			genesisHash,
+			rapidGossipSyncUrl: 'https://rapidsync.lightningdevkit.org/snapshot/',
 		});
 		if (networkGraphRes.isErr()) {
 			return networkGraphRes;
@@ -1352,6 +1358,11 @@ class LightningManager {
 		console.log(
 			`Emergency closed channel ${channel_id} with peer ${counterparty_node_id}`,
 		);
+	}
+
+	private onNetworkGraphReady(res: TNetworkGraphReady): void {
+		console.log(`Network graph nodes: ${res.node_count}`);
+		console.log(`Network graph channels: ${res.channel_count}`);
 	}
 }
 

--- a/lib/src/lightning-manager.ts
+++ b/lib/src/lightning-manager.ts
@@ -43,7 +43,7 @@ import {
 	TPaymentReq,
 	TPaymentTimeoutReq,
 	TLdkPaymentIds,
-	TNetworkGraphReady,
+	TNetworkGraphUpdated,
 } from './utils/types';
 import {
 	appendPath,
@@ -183,8 +183,8 @@ class LightningManager {
 			this.onEmergencyForceCloseChannel.bind(this),
 		);
 		ldk.onEvent(
-			EEventTypes.network_graph_ready,
-			this.onNetworkGraphReady.bind(this),
+			EEventTypes.network_graph_updated,
+			this.onNetworkGraphUpdated.bind(this),
 		);
 	}
 
@@ -366,10 +366,16 @@ class LightningManager {
 		// Step 7: Read ChannelMonitors state from disk
 		// Handled in initChannelManager below
 
+		//TODO allow users to override
+		let rapidGossipSyncUrl = '';
+		if (network === 'mainnet') {
+			rapidGossipSyncUrl = 'https://rapidsync.lightningdevkit.org/snapshot/';
+		}
+
 		// Step 11: Optional: Initialize the NetGraphMsgHandler
 		const networkGraphRes = await ldk.initNetworkGraph({
 			genesisHash,
-			rapidGossipSyncUrl: 'https://rapidsync.lightningdevkit.org/snapshot/',
+			rapidGossipSyncUrl,
 		});
 		if (networkGraphRes.isErr()) {
 			return networkGraphRes;
@@ -1360,7 +1366,7 @@ class LightningManager {
 		);
 	}
 
-	private onNetworkGraphReady(res: TNetworkGraphReady): void {
+	private onNetworkGraphUpdated(res: TNetworkGraphUpdated): void {
 		console.log(`Network graph nodes: ${res.node_count}`);
 		console.log(`Network graph channels: ${res.channel_count}`);
 	}

--- a/lib/src/utils/types.ts
+++ b/lib/src/utils/types.ts
@@ -25,7 +25,7 @@ export enum EEventTypes {
 	channel_manager_payment_claimed = 'channel_manager_payment_claimed',
 	emergency_force_close_channel = 'emergency_force_close_channel',
 	new_channel = 'new_channel',
-	network_graph_ready = 'network_graph_ready',
+	network_graph_updated = 'network_graph_updated',
 }
 
 //LDK event responses
@@ -174,7 +174,7 @@ export type TInvoice = {
 	route_hints: RouteHints[];
 };
 
-export type TNetworkGraphReady = {
+export type TNetworkGraphUpdated = {
 	channel_count: number;
 	node_count: number;
 };

--- a/lib/src/utils/types.ts
+++ b/lib/src/utils/types.ts
@@ -25,6 +25,7 @@ export enum EEventTypes {
 	channel_manager_payment_claimed = 'channel_manager_payment_claimed',
 	emergency_force_close_channel = 'emergency_force_close_channel',
 	new_channel = 'new_channel',
+	network_graph_ready = 'network_graph_ready',
 }
 
 //LDK event responses
@@ -173,6 +174,11 @@ export type TInvoice = {
 	route_hints: RouteHints[];
 };
 
+export type TNetworkGraphReady = {
+	channel_count: number;
+	node_count: number;
+};
+
 export type RouteHints = RouteHintHop[];
 
 export type RouteHintHop = {
@@ -263,6 +269,7 @@ export type TInitChannelManagerReq = {
 
 export type TInitNetworkGraphReq = {
 	genesisHash: string;
+	rapidGossipSyncUrl?: string;
 };
 
 export type TInitConfig = {


### PR DESCRIPTION
iOS rapid gossip sync.

Note: incremental updates temporally disabled due to this [LDK issue](https://github.com/lightningdevkit/rust-lightning/issues/1784). Right now if a network graph is older than 24h we download a rapid gossip sync file from scratch (~5mb) but once patched these few lines can be removed to enable updates without downloading graph once a day.