### PR TITLE
fix(lightning): Add getTransactionPosition

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -282,7 +282,7 @@ PODS:
   - React-jsinspector (0.68.2)
   - React-logger (0.68.2):
     - glog
-  - react-native-ldk (0.0.71):
+  - react-native-ldk (0.0.72):
     - React
   - react-native-randombytes (3.6.1):
     - React-Core
@@ -559,7 +559,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: b7b553412f2ec768fe6c8f27cd6bafdb9d8719e6
   React-jsinspector: c5989c77cb89ae6a69561095a61cce56a44ae8e8
   React-logger: a0833912d93b36b791b7a521672d8ee89107aff1
-  react-native-ldk: 56d14b6cc7e481655e2b6ce2ab507fecfe5ac6ff
+  react-native-ldk: f82ff4ffa9cefa239e3d24c1e15cfac00d135707
   react-native-randombytes: 421f1c7d48c0af8dbcd471b0324393ebf8fe7846
   react-native-tcp-socket: c1b7297619616b4c9caae6889bcb0aba78086989
   React-perflogger: a18b4f0bd933b8b24ecf9f3c54f9bf65180f3fe6

--- a/example/ldk/index.ts
+++ b/example/ldk/index.ts
@@ -15,6 +15,7 @@ import lm, {
 	TAccountBackup,
 	THeader,
 	TTransactionData,
+	TTransactionPosition,
 } from '@synonymdev/react-native-ldk';
 import ldk from '@synonymdev/react-native-ldk/dist/ldk';
 import { peers, selectedNetwork } from '../utils/constants';
@@ -120,6 +121,7 @@ export const setupLdk = async (): Promise<Result<string>> => {
 			getAddress,
 			getScriptPubKeyHistory,
 			getTransactionData,
+			getTransactionPosition,
 			broadcastTransaction,
 			network: ldkNetwork(selectedNetwork),
 		});
@@ -217,6 +219,27 @@ export const getTransactionData = async (
 		transaction: hex_encoded_tx,
 		vout: voutData,
 	};
+};
+
+/**
+ * Returns the position/index of the provided tx_hash within a block.
+ * @param {string} tx_hash
+ * @param {number} height
+ * @returns {Promise<number>}
+ */
+export const getTransactionPosition = async ({
+	tx_hash,
+	height,
+}): Promise<TTransactionPosition> => {
+	const response = await electrum.getTransactionMerkle({
+		tx_hash,
+		height,
+		network: selectedNetwork,
+	});
+	if (response.error || isNaN(response.data?.pos || response.data?.pos < 0)) {
+		return -1;
+	}
+	return response.data.pos;
 };
 
 /**

--- a/example/package.json
+++ b/example/package.json
@@ -34,7 +34,7 @@
     "react-native-randombytes": "^3.6.1",
     "react-native-tcp-socket": "^5.6.2",
     "readable-stream": "^4.0.0",
-    "rn-electrum-client": "git+http://git@github.com/synonymdev/react-native-electrum-client#1515d57a61bcad5ee70e21cd1a1ca8054d4e34ca",
+    "rn-electrum-client": "synonymdev/react-native-electrum-client#8/head",
     "stream-browserify": "^3.0.0",
     "vm-browserify": "^1.1.2"
   },

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -6860,9 +6860,9 @@ ripemd160@^2.0.0, ripemd160@^2.0.1, ripemd160@^2.0.2:
     hash-base "^3.0.0"
     inherits "^2.0.1"
 
-"rn-electrum-client@git+http://git@github.com/synonymdev/react-native-electrum-client#1515d57a61bcad5ee70e21cd1a1ca8054d4e34ca":
+rn-electrum-client@synonymdev/react-native-electrum-client#8/head:
   version "0.0.8"
-  resolved "git+http://git@github.com/synonymdev/react-native-electrum-client#1515d57a61bcad5ee70e21cd1a1ca8054d4e34ca"
+  resolved "https://codeload.github.com/synonymdev/react-native-electrum-client/tar.gz/206010a04cfc2a219d04d3faaf4c25a6c4135971"
 
 rn-nodeify@^10.3.0:
   version "10.3.0"

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@synonymdev/react-native-ldk",
   "title": "React Native LDK",
-  "version": "0.0.71",
+  "version": "0.0.72",
   "description": "React Native wrapper for LDK",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/lib/src/utils/helpers.ts
+++ b/lib/src/utils/helpers.ts
@@ -21,6 +21,7 @@ export const startParamCheck = async ({
 	genesisHash,
 	getBestBlock,
 	getTransactionData,
+	getTransactionPosition,
 	broadcastTransaction,
 	getAddress,
 	getScriptPubKeyHistory,
@@ -70,6 +71,11 @@ export const startParamCheck = async ({
 			return err('getTransactionData must be a function.');
 		}
 
+		// Test getTransactionPosition
+		if (!isFunction(getTransactionPosition)) {
+			return err('getTransactionPosition must be a function.');
+		}
+
 		// Test getAddress
 		if (!isFunction(getAddress)) {
 			return err('getAddress must be a function.');
@@ -90,6 +96,7 @@ export const startParamCheck = async ({
 				[ENetworks.mainnet]: {
 					txid: '0e3e2357e806b6cdb1f70b54c3a3a17b6714ee1f0e68bebb44a74b1efd512098',
 					data: {
+						pos: 0,
 						header:
 							'010000006fe28c0ab6f1b372c1a6a246ae63f74f931e8365e15a089c68d6190000000000982051fd1e4ba744bbbe680e1fee14677ba1a3c3540bf7b1cdb606e857233e0e61bc6649ffff001d01e36299',
 						height: 1,
@@ -107,6 +114,7 @@ export const startParamCheck = async ({
 				[ENetworks.testnet]: {
 					txid: 'f0315ffc38709d70ad5647e22048358dd3745f3ce3874223c80a7c92fab0c8ba',
 					data: {
+						pos: 0,
 						header:
 							'0100000043497fd7f826957108f4a30fd9cec3aeba79972084e90ead01ea330900000000bac8b0fa927c0ac8234287e33c5f74d38d354820e24756ad709d7038fc5f31f020e7494dffff001d03e4b672',
 						height: 1,
@@ -155,6 +163,22 @@ export const startParamCheck = async ({
 			if (transactionData.vout[0]?.value !== data.vout[0].value) {
 				return err(
 					'getTransactionData is not returning the expected vout[0].value',
+				);
+			}
+
+			const transactionPosition = await getTransactionPosition({
+				tx_hash: expectedData[network].txid,
+				height: expectedData[network].data.height,
+			});
+			if (isNaN(transactionPosition)) {
+				return err('getTransactionPosition is not returning a number.');
+			}
+			if (transactionPosition < 0) {
+				return err('getTransactionPosition is returning a negative integer.');
+			}
+			if (transactionPosition !== data.pos) {
+				return err(
+					'getTransactionPosition is not returning the expected transaction position.',
 				);
 			}
 

--- a/lib/src/utils/types.ts
+++ b/lib/src/utils/types.ts
@@ -300,6 +300,8 @@ export type TTransactionData = {
 	vout: TVout[];
 };
 
+export type TTransactionPosition = number;
+
 export type TClaimableBalance = {
 	claimable_amount_satoshis: number;
 	type:
@@ -341,6 +343,10 @@ export const DefaultTransactionDataShape: TTransactionData = {
 };
 
 export type TGetTransactionData = (txid: string) => Promise<TTransactionData>;
+export type TGetTransactionPosition = (params: {
+	tx_hash: string;
+	height: number;
+}) => Promise<TTransactionPosition>;
 export type TGetBestBlock = () => Promise<THeader>;
 
 export enum ELdkFiles {
@@ -421,6 +427,7 @@ export type TLdkStart = {
 	genesisHash: string;
 	getBestBlock: TGetBestBlock;
 	getTransactionData: TGetTransactionData;
+	getTransactionPosition: TGetTransactionPosition;
 	getAddress: TGetAddress;
 	getScriptPubKeyHistory: TGetScriptPubKeyHistory;
 	broadcastTransaction: TBroadcastTransaction;


### PR DESCRIPTION
This PR:
- Adds `getTransactionPosition` to `lm.start`.
- Corrects invalid `setConfirmedTx` params.
  - We're now grabbing the relevant position of the tx in the block and passing that to `setConfirmedTx`'s `txData` object instead of the output's index.
  - We are now passing the full tx to the `txData` object.
- Bumps version to `0.0.72`.