### PR TITLE
Backup all past channels

### DIFF
--- a/lib/android/src/main/java/com/reactnativeldk/LdkModule.kt
+++ b/lib/android/src/main/java/com/reactnativeldk/LdkModule.kt
@@ -287,8 +287,12 @@ class LdkModule(reactContext: ReactApplicationContext) : ReactContextBaseJavaMod
         keysManager ?: return handleReject(promise, LdkErrors.init_keys_manager)
         userConfig ?: return handleReject(promise, LdkErrors.init_user_config)
         networkGraph ?: return handleReject(promise, LdkErrors.init_network_graph)
-        accountStoragePath ?: return handleReject(promise, LdkErrors.init_storage_path)
-        channelStoragePath ?: return handleReject(promise, LdkErrors.init_storage_path)
+        if (accountStoragePath == "") {
+            return handleReject(promise, LdkErrors.init_storage_path)
+        }
+        if (channelStoragePath == "") {
+            return handleReject(promise, LdkErrors.init_storage_path)
+        }
 
         when (network) {
             "regtest" -> {
@@ -705,6 +709,22 @@ class LdkModule(reactContext: ReactApplicationContext) : ReactContextBaseJavaMod
 
         val list = Arguments.createArray()
         channelManager!!.list_usable_channels().iterator().forEach { list.pushMap(it.asJson) }
+
+        promise.resolve(list)
+    }
+
+    @ReactMethod
+    fun listChannelFiles(promise: Promise) {
+        if (channelStoragePath == "") {
+            return handleReject(promise, LdkErrors.init_storage_path)
+        }
+        
+        val list = Arguments.createArray()
+        Files.walk(Paths.get(channelStoragePath))
+            .filter { Files.isRegularFile(it) }
+            .forEach {
+                list.pushString(it.fileName.toString())
+            }
 
         promise.resolve(list)
     }

--- a/lib/ios/Ldk.m
+++ b/lib/ios/Ldk.m
@@ -84,6 +84,8 @@ RCT_EXTERN_METHOD(listChannels:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject)
 RCT_EXTERN_METHOD(listUsableChannels:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject)
+RCT_EXTERN_METHOD(listChannelFiles:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject)
 RCT_EXTERN_METHOD(networkGraphListNodes:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject)
 RCT_EXTERN_METHOD(networkGraphListChannels:(RCTPromiseResolveBlock)resolve

--- a/lib/ios/Ldk.swift
+++ b/lib/ios/Ldk.swift
@@ -806,6 +806,15 @@ class Ldk: NSObject {
     }
     
     @objc
+    func listChannelFiles(_ resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+        guard let channelStoragePath = Ldk.channelStoragePath else {
+            return handleReject(reject, .init_storage_path)
+        }
+        
+        return resolve(try! FileManager.default.contentsOfDirectory(at: channelStoragePath, includingPropertiesForKeys: nil).map { $0.lastPathComponent })
+    }
+    
+    @objc
     func networkGraphListNodes(_ resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
         guard let networkGraph = networkGraph?.read_only() else {
             return handleReject(reject, .init_network_graph)

--- a/lib/src/ldk.ts
+++ b/lib/src/ldk.ts
@@ -648,6 +648,20 @@ class LDK {
 	}
 
 	/**
+	 * Lists all files in channel directory to be backed up.
+	 * Will include past and current channels.
+	 * @returns {Promise<Ok<Ok<string[]> | Err<string[]>> | Err<unknown>>}
+	 */
+	async listChannelFiles(): Promise<Result<string[]>> {
+		try {
+			const res = await NativeLDK.listChannelFiles();
+			return ok(res);
+		} catch (e) {
+			return err(e);
+		}
+	}
+
+	/**
 	 * Fetches list of node IDs in network graph
 	 * https://docs.rs/lightning/latest/lightning/routing/gossip/struct.ReadOnlyNetworkGraph.html#method.nodes
 	 * @returns {Promise<Ok<Ok<string[]> | Err<string[]>> | Err<unknown>>}

--- a/lib/src/lightning-manager.ts
+++ b/lib/src/lightning-manager.ts
@@ -851,17 +851,17 @@ class LightningManager {
 			}
 
 			//Get serialised channels
-			const listChannelsRes = await ldk.listChannels();
+			const listChannelsRes = await ldk.listChannelFiles();
 			if (listChannelsRes.isErr()) {
 				return err(listChannelsRes.error);
 			}
 
 			let channel_monitors: { [key: string]: string } = {};
 			for (let index = 0; index < listChannelsRes.value.length; index++) {
-				const { channel_id } = listChannelsRes.value[index];
+				const fileName = listChannelsRes.value[index];
 
 				const serialisedChannelRes = await ldk.readFromFile({
-					fileName: `${channel_id}.bin`,
+					fileName,
 					path: appendPath(accountPath, ELdkFiles.channels),
 					format: 'hex',
 				});
@@ -869,7 +869,8 @@ class LightningManager {
 					return err(serialisedChannelRes.error);
 				}
 
-				channel_monitors[channel_id] = serialisedChannelRes.value.content;
+				channel_monitors[fileName.replace('.bin', '')] =
+					serialisedChannelRes.value.content;
 			}
 
 			const accountBackup: TAccountBackup = {


### PR DESCRIPTION
- `ldkListChannelFiles()` Returns all channel monitor file names.
- Backup all channel monitors instead of just current channels. Safer to back up everything in case there are still unclaimed funds from previously closed channels.
- Backups now work without starting LDK.