### PR TITLE
Android rapid gossip sync

### DIFF
--- a/lib/android/src/main/java/com/reactnativeldk/LdkModule.kt
+++ b/lib/android/src/main/java/com/reactnativeldk/LdkModule.kt
@@ -373,9 +373,7 @@ class LdkModule(reactContext: ReactApplicationContext) : ReactContextBaseJavaMod
                 return handleReject(promise, LdkErrors.invalid_network)
             }
         }
-
-        var enableP2PGossipSync = rapidGossipSync == null
-
+        
         var channelManagerSerialized: ByteArray? = null
         val channelManagerFile = File(accountStoragePath + "/" + LdkFileNames.channel_manager.fileName)
         if (channelManagerFile.exists()) {
@@ -402,7 +400,7 @@ class LdkModule(reactContext: ReactApplicationContext) : ReactContextBaseJavaMod
                     feeEstimator.feeEstimator,
                     chainMonitor,
                     filter.filter,
-                    if (enableP2PGossipSync) networkGraph!!.write() else null,
+                    networkGraph!!.write(),
                     broadcaster.broadcaster,
                     logger.logger
                 )
@@ -417,7 +415,7 @@ class LdkModule(reactContext: ReactApplicationContext) : ReactContextBaseJavaMod
                     keysManager!!.as_KeysInterface(),
                     feeEstimator.feeEstimator,
                     chainMonitor,
-                    if (enableP2PGossipSync) networkGraph!! else null,
+                    networkGraph!!,
                     broadcaster.broadcaster,
                     logger.logger,
                 )

--- a/lib/android/src/main/java/com/reactnativeldk/classes/LdkPersister.kt
+++ b/lib/android/src/main/java/com/reactnativeldk/classes/LdkPersister.kt
@@ -18,9 +18,9 @@ class LdkPersister {
                 throw Exception("Channel storage path not set")
             }
 
-            var file = File(LdkModule.channelStoragePath + "/" + id.to_channel_id().hexEncodedString() + ".bin")
+            val file = File(LdkModule.channelStoragePath + "/" + id.to_channel_id().hexEncodedString() + ".bin")
 
-            var isNew = !file.exists()
+            val isNew = !file.exists()
 
             file.writeBytes(data.write())
 

--- a/lib/ios/Ldk.swift
+++ b/lib/ios/Ldk.swift
@@ -258,7 +258,6 @@ class Ldk: NSObject {
             LdkEventEmitter.shared.send(withEvent: .native_log, body: "Failed to load cached network graph from disk. Will sync from scratch. \(error.localizedDescription)")
         }
         
-        
         //Download url passed, enable rapid gossip sync
         if rapidGossipSyncUrl != "" {
             do {
@@ -278,13 +277,17 @@ class Ldk: NSObject {
                     return handleResolve(resolve, .network_graph_init_success)
                 }
                 
+                LdkEventEmitter.shared.send(withEvent: .native_log, body: "Rapid gossip sync applying update. Last updated \(hoursDiffSinceLastRGS) hours ago.")
+                
                 //TODO remove this incremental updates temp broken. Possibly related to https://github.com/lightningdevkit/rust-lightning/issues/1784
+                //TODO check if this is still an issue in 0.0.113
                 //If network graph is older than 24h download from scratch until incremental updates are working
                 //>>>>>> DELETE ME
                 try? FileManager().removeItem(atPath: accountStoragePath.appendingPathComponent(LdkFileNames.network_graph.rawValue).path)
                 networkGraph = NetworkGraph(genesis_hash: String(genesisHash).hexaBytes, logger: logger)
                 rapidGossipSync = RapidGossipSync(network_graph: networkGraph!)
                 timestamp = 0
+                LdkEventEmitter.shared.send(withEvent: .native_log, body: "Rapid sync from scratch. Try remove in 0.0.113.")
                 //<<<<<< DELETE ME
                 
                 rapidGossipSync!.downloadAndUpdateGraph(downloadUrl: String(rapidGossipSyncUrl), tempStoragePath: rapidGossipSyncStoragePath, timestamp: timestamp) { [weak self] error in


### PR DESCRIPTION
- Android rapid gossip sync
- Android limit graph queries to avoid memory limit crashes in RN
- There's [this issue](https://github.com/lightningdevkit/rust-lightning/issues/1784) in LDK causing some rapid gossip syncing to fail. It's been fixed but waiting on 0.0.113 to test. For now the graph will sync from scratch (downloading 5mb) every 24 hours.