### PR TITLE
iOS fixed invoice description

### DIFF
--- a/lib/ios/Helpers.swift
+++ b/lib/ios/Helpers.swift
@@ -26,9 +26,15 @@ func handleReject(_ reject: RCTPromiseRejectBlock, _ ldkError: LdkErrors, _ erro
 
 extension Invoice {
     var asJson: Any {
+        //Break down to get the decription. Will crash if all on a single line.
+        let signedRawInvoice = into_signed_raw()
+        let rawInvoice = signedRawInvoice.raw_invoice()
+        let description = rawInvoice.description()
+        let descriptionString = description.into_inner()
+        
         return [
             "amount_satoshis": amount_milli_satoshis().getValue() != nil ? amount_milli_satoshis().getValue()! / 1000 : nil,
-            "description": into_signed_raw().raw_invoice().description(),
+            "description": descriptionString,
             "check_signature": check_signature().isOk(),
             "is_expired": is_expired(),
             "duration_since_epoch": duration_since_epoch(),

--- a/lib/src/ldk.ts
+++ b/lib/src/ldk.ts
@@ -30,6 +30,7 @@ import {
 	TFileWriteReq,
 	TClaimableBalance,
 } from './utils/types';
+import { extractPaymentRequest } from './utils/helpers';
 
 const LINKING_ERROR =
 	"The package 'react-native-ldk' doesn't seem to be linked. Make sure: \n\n" +
@@ -417,8 +418,9 @@ class LDK {
 	 * @returns {Promise<Ok<any> | Err<unknown>>}
 	 */
 	async decode({ paymentRequest }: TPaymentReq): Promise<Result<TInvoice>> {
+		const cleanedPaymentRequest = extractPaymentRequest(paymentRequest);
 		try {
-			const res = await NativeLDK.decode(paymentRequest);
+			const res = await NativeLDK.decode(cleanedPaymentRequest);
 			return ok(res);
 		} catch (e) {
 			return err(e);
@@ -482,9 +484,11 @@ class LDK {
 	 * @returns {Promise<Err<unknown> | Ok<Ok<string> | Err<string>>>}
 	 */
 	async pay({
-		paymentRequest,
+		paymentRequest: anyPaymentRequest,
 		amountSats,
 	}: TPaymentReq): Promise<Result<string>> {
+		const paymentRequest = extractPaymentRequest(anyPaymentRequest);
+
 		//If no usable channels don't even attempt payment
 		const channelsRes = await this.listUsableChannels();
 		if (channelsRes.isOk() && channelsRes.value.length === 0) {

--- a/lib/src/utils/helpers.ts
+++ b/lib/src/utils/helpers.ts
@@ -219,6 +219,17 @@ const validateAddress = ({
 	}
 };
 
+/**
+ * Extracts actual invoice string request from common formats that include lightning invoices
+ * @param invoice
+ * @returns {string}
+ */
+export const extractPaymentRequest = (paymentRequest: string): string => {
+	const result = paymentRequest.replace('lightning:', '').toLowerCase();
+	//TODO support bip21 and other common formats
+	return result;
+};
+
 const isFunction = (f: any): boolean => {
 	try {
 		return f && {}.toString.call(f) === '[object Function]';


### PR DESCRIPTION
- Returns correct invoice description instead of null
- Removes `lightning:` from invoices. At a later stage we can add bip21 support so anyone using using this doesn't have to worry about parsing multiple formats first when decoding lightning invoices.