### PR TITLE
Remove RGS hacks

### DIFF
--- a/lib/android/src/main/java/com/reactnativeldk/Helpers.kt
+++ b/lib/android/src/main/java/com/reactnativeldk/Helpers.kt
@@ -217,6 +217,10 @@ fun RapidGossipSync.downloadAndUpdateGraph(downloadUrl: String, tempStoragePath:
     val destinationFile = "$tempStoragePath$timestamp.bin"
 
     URL(downloadUrl + timestamp).downloadFile(destinationFile) {
+        if (it != null) {
+            return@downloadFile completion(it)
+        }
+
         val res = update_network_graph(File(destinationFile).readBytes())
         if (!res.is_ok()) {
             val error = res as? Result_u32GraphSyncErrorZ.Result_u32GraphSyncErrorZ_Err

--- a/lib/android/src/main/java/com/reactnativeldk/Helpers.kt
+++ b/lib/android/src/main/java/com/reactnativeldk/Helpers.kt
@@ -37,6 +37,31 @@ fun String.hexa(): ByteArray {
         .toByteArray()
 }
 
+fun getProbabilisticScorer(path: String, networkGraph: NetworkGraph, logger: Logger): ProbabilisticScorer? {
+    val params = ProbabilisticScoringParameters.with_default()
+
+    val scorerFile = File(path + "/" + LdkFileNames.scorer.fileName)
+    if (scorerFile.exists()) {
+        val read = ProbabilisticScorer.read(scorerFile.readBytes(), params, networkGraph, logger)
+        if (read.is_ok) {
+            LdkEventEmitter.send(EventTypes.native_log, "Loaded scorer from disk")
+            return (read as Result_ProbabilisticScorerDecodeErrorZ.Result_ProbabilisticScorerDecodeErrorZ_OK).res
+        } else {
+            LdkEventEmitter.send(EventTypes.native_log, "Failed to load cached scorer")
+        }
+    }
+
+    val default_scorer = ProbabilisticScorer.of(params, networkGraph, logger)
+    val score_res = ProbabilisticScorer.read(
+        default_scorer.write(), params, networkGraph,
+        logger
+    )
+    if (!score_res.is_ok) {
+        return null
+    }
+    return (score_res as Result_ProbabilisticScorerDecodeErrorZ.Result_ProbabilisticScorerDecodeErrorZ_OK).res
+}
+
 val Invoice.asJson: WritableMap
     get() {
         val result = Arguments.createMap()

--- a/lib/android/src/main/java/com/reactnativeldk/Helpers.kt
+++ b/lib/android/src/main/java/com/reactnativeldk/Helpers.kt
@@ -226,15 +226,15 @@ fun RapidGossipSync.downloadAndUpdateGraph(downloadUrl: String, tempStoragePath:
             val error = res as? Result_u32GraphSyncErrorZ.Result_u32GraphSyncErrorZ_Err
 
             (error?.err as? GraphSyncError.LightningError)?.let { lightningError ->
-                return@downloadFile completion(Error("Rapid sync GraphSyncError.LightningError. " + lightningError.lightning_error._err))
+                return@downloadFile completion(Error("Rapid sync LightningError. " + lightningError.lightning_error._err))
             }
 
             (error?.err as? GraphSyncError.DecodeError)?.let { decodeError ->
                 (decodeError.decode_error as? DecodeError.Io)?.let { decodeIOError ->
-                    return@downloadFile completion(Error("Rapid sync GraphSyncError.DecodeError. " + decodeIOError.io.ordinal))
+                    return@downloadFile completion(Error("Rapid sync DecodeError. " + decodeIOError.io.ordinal))
                 }
 
-                return@downloadFile completion(Error("Rapid sync GraphSyncError.DecodeError"))
+                return@downloadFile completion(Error("Rapid sync DecodeError"))
             }
 
             return@downloadFile completion(Error("Unknown rapid sync error."))

--- a/lib/android/src/main/java/com/reactnativeldk/classes/LdkChannelManagerPersister.kt
+++ b/lib/android/src/main/java/com/reactnativeldk/classes/LdkChannelManagerPersister.kt
@@ -155,7 +155,9 @@ class LdkChannelManagerPersister: ChannelManagerConstructor.EventHandler {
     }
 
     override fun persist_scorer(p0: ByteArray?) {
-        //TODO
-        println("TODO Kotlin persist scorer")
+        if (p0 != null && LdkModule.accountStoragePath != "") {
+            File(LdkModule.accountStoragePath + "/" + LdkFileNames.scorer.fileName).writeBytes(p0)
+            LdkEventEmitter.send(EventTypes.native_log, "Persisted scorer to disk")
+        }
     }
 }

--- a/lib/android/src/main/java/com/reactnativeldk/classes/LdkLogger.kt
+++ b/lib/android/src/main/java/com/reactnativeldk/classes/LdkLogger.kt
@@ -27,8 +27,6 @@ class LdkLogger {
         if (activeLevels[level] == true) {
             LdkEventEmitter.send(EventTypes.ldk_log, record._args)
             LogFile.write( "$level (LDK): ${record._args}")
-        } else {
-            println("Skipping log level $level")
         }
     }
 

--- a/lib/ios/Classes/LdkChannelManagerPersister.swift
+++ b/lib/ios/Classes/LdkChannelManagerPersister.swift
@@ -251,7 +251,6 @@ class LdkChannelManagerPersister: Persister, ExtendedChannelManagerPersister {
                 
         do {
             try Data(scorer.write()).write(to: scorerStorage)
-            LdkEventEmitter.shared.send(withEvent: .native_log, body: "TODO persist scorer to disk")
         
             return Result_NoneErrorZ.initWithOk()
         } catch {

--- a/lib/ios/Helpers.swift
+++ b/lib/ios/Helpers.swift
@@ -285,10 +285,10 @@ extension RapidGossipSync {
                 var errorMessage = "Failed to update network graph."
                 switch res.getError()?.getValueType() {
                 case .LightningError:
-                    errorMessage = "Rapid sync error. \(res.getError()!.getValueAsLightningError()!.getErr())" //Couldn't find channel for update.
+                    errorMessage = "Rapid sync LightningError. \(res.getError()!.getValueAsLightningError()!.getErr())" //Couldn't find channel for update.
                     break;
                 case .DecodeError:
-                    errorMessage = "Rapid sync error. IO error: \(res.getError()!.getValueAsDecodeError()?.getValueType())"
+                    errorMessage = "Rapid sync DecodeError. IO error: \(res.getError()!.getValueAsDecodeError()?.getValueType())"
                     break;
                 default:
                     errorMessage = "Unknown rapid sync error."

--- a/lib/ios/Ldk.swift
+++ b/lib/ios/Ldk.swift
@@ -273,71 +273,73 @@ class Ldk: NSObject {
             LdkEventEmitter.shared.send(withEvent: .native_log, body: "Failed to load cached network graph from disk. Will sync from scratch. \(error.localizedDescription)")
         }
         
+        //Normal p2p gossip sync
+        guard rapidGossipSyncUrl != "" else {
+            return handleResolve(resolve, .network_graph_init_success)
+        }
+        
         print("rapidGossipSyncUrl: \(rapidGossipSyncUrl)")
         
         //Download url passed, enable rapid gossip sync
-        if rapidGossipSyncUrl != "" {
-            do {
-                let rapidGossipSyncStoragePath = accountStoragePath.appendingPathComponent("rapid_gossip_sync")
-                if !FileManager().fileExists(atPath: rapidGossipSyncStoragePath.path) {
-                    try FileManager.default.createDirectory(atPath: rapidGossipSyncStoragePath.path, withIntermediateDirectories: true, attributes: nil)
-                }
-
-                rapidGossipSync = RapidGossipSync(networkGraph: networkGraph!)
-                                
-                //If it's been more than 24 hours then we need to update RGS
-                var timestamp = networkGraph?.getLastRapidGossipSyncTimestamp() ?? 0
-                let hoursDiffSinceLastRGS = (Calendar.current.dateComponents([.hour], from: Date.init(timeIntervalSince1970: TimeInterval(timestamp)), to: Date()).hour)!
-               
-                guard hoursDiffSinceLastRGS > 24 else {
-                    LdkEventEmitter.shared.send(withEvent: .native_log, body: "Skipping rapid gossip sync. Last updated \(hoursDiffSinceLastRGS) hours ago.")
-                    return handleResolve(resolve, .network_graph_init_success)
-                }
-                
-                LdkEventEmitter.shared.send(withEvent: .native_log, body: "Rapid gossip sync applying update. Last updated \(hoursDiffSinceLastRGS) hours ago.")
-                
-                //TODO remove this incremental updates temp broken. Possibly related to https://github.com/lightningdevkit/rust-lightning/issues/1784
-                //TODO check if this is still an issue in 0.0.113
-                //If network graph is older than 24h download from scratch until incremental updates are working
-                //>>>>>> DELETE ME
-                try? FileManager().removeItem(atPath: accountStoragePath.appendingPathComponent(LdkFileNames.network_graph.rawValue).path)
-                networkGraph = NetworkGraph(genesisHash: String(genesisHash).hexaBytes.reversed(), logger: logger)
-                rapidGossipSync = RapidGossipSync(networkGraph: networkGraph!)
-                timestamp = 0
-                LdkEventEmitter.shared.send(withEvent: .native_log, body: "Rapid sync from scratch. Try remove in 0.0.113.")
-                //<<<<<< DELETE ME
-                
-                rapidGossipSync!.downloadAndUpdateGraph(downloadUrl: String(rapidGossipSyncUrl), tempStoragePath: rapidGossipSyncStoragePath, timestamp: timestamp) { [weak self] error in
-                    guard let self = self else { return }
-                    
-                    LdkEventEmitter.shared.send(withEvent: .native_log, body: "Rapid gossip sync file downloaded.")
-                    
-                    if let error = error {
-                        return LdkEventEmitter.shared.send(withEvent: .native_log, body: "Failed to download rapid sync file. \(error.localizedDescription).")
-                    }
-
-                    LdkEventEmitter.shared.send(withEvent: .native_log, body: "Rapid gossip sync completed.")
-
-                    guard let graph = self.networkGraph?.readOnly() else {
-                        return LdkEventEmitter.shared.send(withEvent: .native_log, body: "Failed to use network graph.")
-                    }
-                    
-                    let _ = self.channelManagerPersister.persistGraph(networkGraph: self.networkGraph!)
-                    
-                    LdkEventEmitter.shared.send(
-                        withEvent: .network_graph_updated,
-                        body: [
-                            "channel_count": graph.listChannels().count,
-                            "node_count": graph.listNodes().count,
-                        ]
-                    )
-                }
-            } catch {
-                return handleReject(reject, .init_network_graph_fail, error)
+        do {
+            let rapidGossipSyncStoragePath = accountStoragePath.appendingPathComponent("rapid_gossip_sync")
+            if !FileManager().fileExists(atPath: rapidGossipSyncStoragePath.path) {
+                try FileManager.default.createDirectory(atPath: rapidGossipSyncStoragePath.path, withIntermediateDirectories: true, attributes: nil)
             }
+
+            rapidGossipSync = RapidGossipSync(networkGraph: networkGraph!)
+                            
+            //If it's been more than 24 hours then we need to update RGS
+            let timestamp = networkGraph?.getLastRapidGossipSyncTimestamp() ?? 0
+            let hoursDiffSinceLastRGS = (Calendar.current.dateComponents([.hour], from: Date.init(timeIntervalSince1970: TimeInterval(timestamp)), to: Date()).hour)!
+           
+            guard hoursDiffSinceLastRGS > 24 else {
+                LdkEventEmitter.shared.send(withEvent: .native_log, body: "Skipping rapid gossip sync. Last updated \(hoursDiffSinceLastRGS) hours ago.")
+                return handleResolve(resolve, .network_graph_init_success)
+            }
+            
+            LdkEventEmitter.shared.send(withEvent: .native_log, body: "Rapid gossip sync applying update. Last updated \(hoursDiffSinceLastRGS) hours ago.")
+            
+            //TODO remove this incremental updates temp broken. Possibly related to https://github.com/lightningdevkit/rust-lightning/issues/1784
+            //TODO check if this is still an issue in 0.0.113
+            //If network graph is older than 24h download from scratch until incremental updates are working
+            //>>>>>> DELETE ME
+//                try? FileManager().removeItem(atPath: accountStoragePath.appendingPathComponent(LdkFileNames.network_graph.rawValue).path)
+//                networkGraph = NetworkGraph(genesisHash: String(genesisHash).hexaBytes.reversed(), logger: logger)
+//                rapidGossipSync = RapidGossipSync(networkGraph: networkGraph!)
+//                timestamp = 0
+//                LdkEventEmitter.shared.send(withEvent: .native_log, body: "Rapid sync from scratch. Try remove in 0.0.113.")
+            //<<<<<< DELETE ME
+            
+            rapidGossipSync!.downloadAndUpdateGraph(downloadUrl: String(rapidGossipSyncUrl), tempStoragePath: rapidGossipSyncStoragePath, timestamp: timestamp) { [weak self] error in
+                guard let self = self else { return }
+                                
+                if let error = error {
+                    LdkEventEmitter.shared.send(withEvent: .native_log, body: "Failed to download rapid sync file. \(error.localizedDescription).")
+                    return handleResolve(resolve, .network_graph_init_success) //Continue like normal, likely fine if we don't have the absolute latest state
+                }
+
+                LdkEventEmitter.shared.send(withEvent: .native_log, body: "Rapid gossip sync completed.")
+
+                guard let graph = self.networkGraph?.readOnly() else {
+                    return handleReject(reject, .init_network_graph_fail, "Failed to use network graph.")
+                }
+                
+                _ = self.channelManagerPersister.persistGraph(networkGraph: self.networkGraph!)
+                
+                LdkEventEmitter.shared.send(
+                    withEvent: .network_graph_updated,
+                    body: [
+                        "channel_count": graph.listChannels().count,
+                        "node_count": graph.listNodes().count,
+                    ]
+                )
+                
+                return handleResolve(resolve, .network_graph_init_success)
+            }
+        } catch {
+            return handleReject(reject, .init_network_graph_fail, error)
         }
-        
-        return handleResolve(resolve, .network_graph_init_success)
     }
 
     @objc
@@ -394,8 +396,8 @@ class Ldk: NSObject {
             LdkEventEmitter.shared.send(withEvent: .native_log, body: "Loading channel from file \(channelFile.lastPathComponent)")
             channelMonitorsSerialized.append([UInt8](try! Data(contentsOf: channelFile.standardizedFileURL)))
         }
-        
-        print("enableP2PGossip \(enableP2PGossip)")
+                
+        LdkEventEmitter.shared.send(withEvent: .native_log, body: "Enabled P2P gossip: \(enableP2PGossip)")
         
         do {
             //Only restore a node if we have existing channel monitors to restore. Else we lose our UserConfig settings when restoring.

--- a/lib/ios/Ldk.swift
+++ b/lib/ios/Ldk.swift
@@ -262,8 +262,10 @@ class Ldk: NSObject {
             return handleReject(reject, .init_storage_path)
         }
 
+        let networkGraphStoragePath = accountStoragePath.appendingPathComponent(LdkFileNames.network_graph.rawValue).standardizedFileURL
+        
         do {
-            let read = NetworkGraph.read(ser: [UInt8](try Data(contentsOf: accountStoragePath.appendingPathComponent(LdkFileNames.network_graph.rawValue).standardizedFileURL)), arg: logger)
+            let read = NetworkGraph.read(ser: [UInt8](try Data(contentsOf: networkGraphStoragePath)), arg: logger)
             if read.isOk() {
                 networkGraph = read.getValue()
                 LdkEventEmitter.shared.send(withEvent: .native_log, body: "Loaded network graph from file")
@@ -300,22 +302,18 @@ class Ldk: NSObject {
             
             LdkEventEmitter.shared.send(withEvent: .native_log, body: "Rapid gossip sync applying update. Last updated \(hoursDiffSinceLastRGS) hours ago.")
             
-            //TODO remove this incremental updates temp broken. Possibly related to https://github.com/lightningdevkit/rust-lightning/issues/1784
-            //TODO check if this is still an issue in 0.0.113
-            //If network graph is older than 24h download from scratch until incremental updates are working
-            //>>>>>> DELETE ME
-//                try? FileManager().removeItem(atPath: accountStoragePath.appendingPathComponent(LdkFileNames.network_graph.rawValue).path)
-//                networkGraph = NetworkGraph(genesisHash: String(genesisHash).hexaBytes.reversed(), logger: logger)
-//                rapidGossipSync = RapidGossipSync(networkGraph: networkGraph!)
-//                timestamp = 0
-//                LdkEventEmitter.shared.send(withEvent: .native_log, body: "Rapid sync from scratch. Try remove in 0.0.113.")
-            //<<<<<< DELETE ME
-            
             rapidGossipSync!.downloadAndUpdateGraph(downloadUrl: String(rapidGossipSyncUrl), tempStoragePath: rapidGossipSyncStoragePath, timestamp: timestamp) { [weak self] error in
                 guard let self = self else { return }
                                 
                 if let error = error {
-                    LdkEventEmitter.shared.send(withEvent: .native_log, body: "Failed to download rapid sync file. \(error.localizedDescription).")
+                    LdkEventEmitter.shared.send(withEvent: .native_log, body: "Rapid gossip sync fail. \(error.localizedDescription).")
+                    
+                    //Temp fix for when a RGS server is changed or reset
+                    if error.localizedDescription.contains("LightningError") {
+                        try? FileManager().removeItem(atPath: networkGraphStoragePath.path)
+                        LdkEventEmitter.shared.send(withEvent: .native_log, body: "Deleting persisted graph. Will sync from scratch on next startup.")
+                    }
+                    
                     return handleResolve(resolve, .network_graph_init_success) //Continue like normal, likely fine if we don't have the absolute latest state
                 }
 
@@ -744,9 +742,6 @@ class Ldk: NSObject {
                 if let cFeatures = channel?.getFeatures() {
                     channelFeatures = cFeatures
                 }
-
-                print("***")
-                print(channelFeatures.write())
 
                 if let nFeatures = networkGraph.node(nodeId: NodeId.initWithPubkey(pubkey: pubKey.hexaBytes))?.getAnnouncementInfo()?.getFeatures() {
                     nodeFeatures = nFeatures


### PR DESCRIPTION
- iOS and Android persisting scorer
- Removes rapid gossip sync hack preventing incremental updates to graph
- Only resolves promise once graph sync is complete to ensure the graph is ready when starting the node so the invoice payer has latest updates.
- Temporary hack that deletes the graph so it syncs from scratch on next load if it gets a `LightningError`. I believe this is caused by switching RGS servers or restarting the server.