### PR TITLE
Bump Kotlin Version

### DIFF
--- a/lib/android/gradle.properties
+++ b/lib/android/gradle.properties
@@ -1,3 +1,3 @@
-Ldk_kotlinVersion=1.3.50
+Ldk_kotlinVersion=1.5.20
 Ldk_compileSdkVersion=29
 Ldk_targetSdkVersion=29


### PR DESCRIPTION
This PR:
- Bumps `Ldk_kotlinVersion` to `1.5.20` in `gradle.properties`.