### PR TITLE
iOS LDK restart and getFees param

### DIFF
--- a/example/ldk/index.ts
+++ b/example/ldk/index.ts
@@ -120,6 +120,12 @@ export const setupLdk = async (): Promise<Result<string>> => {
 			account,
 			getAddress,
 			getScriptPubKeyHistory,
+			getFees: () =>
+				Promise.resolve({
+					highPriority: 12500,
+					normal: 12500,
+					background: 12500,
+				}),
 			getTransactionData,
 			getTransactionPosition,
 			broadcastTransaction,

--- a/lib/android/src/main/java/com/reactnativeldk/Helpers.kt
+++ b/lib/android/src/main/java/com/reactnativeldk/Helpers.kt
@@ -127,7 +127,6 @@ val ChannelDetails.asJson: WritableMap
         (_inbound_scid_alias as? Option_u64Z.Some)?.some?.toInt()
             ?.let { result.putInt("inbound_payment_scid", it) }
         result.putInt("inbound_capacity_sat", _inbound_capacity_msat.toInt() / 1000)
-        result.putString("inbound_capacity_msat_str", "$_inbound_capacity_msat")
         result.putInt("outbound_capacity_sat", _outbound_capacity_msat.toInt() / 1000)
         result.putInt("channel_value_satoshis", _channel_value_satoshis.toInt())
         (_force_close_spend_delay as? Option_u16Z.Some)?.some?.toInt()

--- a/lib/android/src/main/java/com/reactnativeldk/Helpers.kt
+++ b/lib/android/src/main/java/com/reactnativeldk/Helpers.kt
@@ -127,6 +127,7 @@ val ChannelDetails.asJson: WritableMap
         (_inbound_scid_alias as? Option_u64Z.Some)?.some?.toInt()
             ?.let { result.putInt("inbound_payment_scid", it) }
         result.putInt("inbound_capacity_sat", _inbound_capacity_msat.toInt() / 1000)
+        result.putString("inbound_capacity_msat_str", "$_inbound_capacity_msat")
         result.putInt("outbound_capacity_sat", _outbound_capacity_msat.toInt() / 1000)
         result.putInt("channel_value_satoshis", _channel_value_satoshis.toInt())
         (_force_close_spend_delay as? Option_u16Z.Some)?.some?.toInt()

--- a/lib/src/utils/helpers.ts
+++ b/lib/src/utils/helpers.ts
@@ -25,6 +25,7 @@ export const startParamCheck = async ({
 	broadcastTransaction,
 	getAddress,
 	getScriptPubKeyHistory,
+	getFees,
 	network = ENetworks.regtest,
 }: TLdkStart): Promise<Result<string>> => {
 	try {
@@ -84,6 +85,11 @@ export const startParamCheck = async ({
 		// Test getScriptPubKeyHistory
 		if (!isFunction(getScriptPubKeyHistory)) {
 			return err('getScriptPubKeyHistory must be a function.');
+		}
+
+		// Test getFees
+		if (!isFunction(getFees)) {
+			return err('getFees must be a function.');
 		}
 
 		if (!isFunction(broadcastTransaction)) {

--- a/lib/src/utils/types.ts
+++ b/lib/src/utils/types.ts
@@ -503,9 +503,9 @@ export type TLdkStart = {
 	getTransactionPosition: TGetTransactionPosition;
 	getAddress: TGetAddress;
 	getScriptPubKeyHistory: TGetScriptPubKeyHistory;
+	getFees: TGetFees;
 	broadcastTransaction: TBroadcastTransaction;
 	network: ENetworks;
-	feeRate?: number;
 	userConfig?: TUserConfig;
 };
 
@@ -518,5 +518,7 @@ export type TGetScriptPubKeyHistory = (
 export type TGetScriptPubKeyHistoryResponse = { height: number; txid: string };
 
 export type TBroadcastTransaction = (rawTx: string) => Promise<any>;
+
+export type TGetFees = () => Promise<TFeeUpdateReq>;
 
 export type TVout = { hex: string; n: number; value: number };

--- a/lib/src/utils/types.ts
+++ b/lib/src/utils/types.ts
@@ -26,6 +26,7 @@ export enum EEventTypes {
 	emergency_force_close_channel = 'emergency_force_close_channel',
 	new_channel = 'new_channel',
 	network_graph_updated = 'network_graph_updated',
+	channel_manager_restarted = 'channel_manager_restarted',
 }
 
 //LDK event responses


### PR DESCRIPTION
On iOS the TCP peer handler doesn't survive the app being put in a suspended state. Current solution was a hack on the app side to reset and startup LDK using the lightning manager from the JS side which sometimes took a few seconds or occasionally failed if accidentally called twice. This rather solves that in swift by using a native observer that triggers a restart each time the app is brought to the foreground. It's only necessary to restart the ChannelManagerContsructor and not every other process so this happens instantly. After restarting, an event is sent back to lightning-manager.ts so it can add peers, set fees and sync again.

`getFees()` function now required as start param. I suspect fees being hard coded is causing issues both with LDK negotiating a channel close (causing a force close) and sweeping the output from a closed channel. We were only passing a `feeRate` which was being used just for sweeping an output and the app implementing was supposed to call ldk.setFees(...). Now the fee fetching function needs to be implemented on the app side and needs to be reasonably aligned with estimates from the counterparty node. When sweeping the output from a closed channel then the `normal` fee rate is automatically chosen.