### PR TITLE
Spend stuck outputs

### DIFF
--- a/example/App.tsx
+++ b/example/App.tsx
@@ -525,16 +525,11 @@ const App = (): ReactElement => {
 							const nodes = await ldk.networkGraphNodes(nodesRes.value);
 							if (nodes.isOk()) {
 								nodes.value.forEach((node) => {
-									const {
-										id,
-										shortChannelIds,
-										lowest_inbound_channel_fees_base_sat,
-										announcement_info_last_update,
-									} = node;
+									const { id, shortChannelIds, announcement_info_last_update } =
+										node;
 									const time = new Date(announcement_info_last_update);
 
 									msg += `\n\n${id}\nChannels: ${shortChannelIds.length}\n`;
-									msg += `Lowest inbound fee: ${lowest_inbound_channel_fees_base_sat} sat\n`;
 									msg += `Last announcement: ${time}`;
 								});
 							}

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -397,6 +397,20 @@ const App = (): ReactElement => {
 					/>
 
 					<Button
+						title={'Recover all outputs attempt'}
+						onPress={async (): Promise<void> => {
+							setMessage('Attempting to respend all outputs...');
+							const res = await lm.recoverOutputs();
+							if (res.isErr()) {
+								setMessage(res.error.message);
+								return;
+							}
+
+							setMessage(res.value);
+						}}
+					/>
+
+					<Button
 						title={'Create invoice'}
 						onPress={async (): Promise<void> => {
 							const createInvoice = async (

--- a/example/package.json
+++ b/example/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "android": "react-native run-android",
     "ios": "react-native run-ios",
-    "start": "react-native start",
+    "start": "watchman watch-del './' ; watchman watch-project './' && react-native start",
     "test": "jest",
     "e2e:build:ios-debug": "detox build --configuration ios.sim.debug",
     "e2e:build:ios-release": "detox build --configuration ios.sim.release",

--- a/lib/android/src/main/java/com/reactnativeldk/LdkModule.kt
+++ b/lib/android/src/main/java/com/reactnativeldk/LdkModule.kt
@@ -630,8 +630,8 @@ class LdkModule(reactContext: ReactApplicationContext) : ReactContextBaseJavaMod
         }
 
         val res = if (isZeroValueInvoice)
-            UtilMethods.pay_zero_value_invoice(invoice, amountSats.toLong() * 1000, Retry.attempts(3), channelManager) else
-            UtilMethods.pay_invoice(invoice, Retry.attempts(3), channelManager)
+            UtilMethods.pay_zero_value_invoice(invoice, amountSats.toLong() * 1000, Retry.timout(60), channelManager) else
+            UtilMethods.pay_invoice(invoice, Retry.timout(60), channelManager)
         if (res.is_ok) {
             return handleResolve(promise, LdkCallbackResponses.invoice_payment_success)
         }

--- a/lib/ios/Ldk.m
+++ b/lib/ios/Ldk.m
@@ -145,6 +145,14 @@ RCT_EXTERN_METHOD(readFromFile:(NSString *)fileName
                   format:(NSString *)format
                   resolve:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject)
+RCT_EXTERN_METHOD(reconstructAndSpendOutputs:(NSString *)outputScriptPubKey
+                  outputValue:(NSInteger *)outputValue
+                  outpointTxId:(NSString *)outpointTxId
+                  outpointIndex:(NSInteger *)outpointIndex
+                  feeRate:(NSInteger *)feeRate
+                  changeDestinationScript:(NSString *)changeDestinationScript
+                  resolve:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject)
 @end
 
 //MARK: Events

--- a/lib/src/ldk.ts
+++ b/lib/src/ldk.ts
@@ -270,9 +270,9 @@ class LDK {
 		line: string,
 	): Promise<Result<string>> {
 		try {
-			const res = await NativeLDK.writeToLogFile(
-				`${type.toUpperCase()} (JS): ${line}`,
-			);
+			const writeLine = `${type.toUpperCase()} (JS): ${line}`;
+			console.log(writeLine);
+			const res = await NativeLDK.writeToLogFile(writeLine);
 			return ok(res);
 		} catch (e) {
 			return err(e);

--- a/lib/src/ldk.ts
+++ b/lib/src/ldk.ts
@@ -31,6 +31,7 @@ import {
 	TPaymentRoute,
 	TPaymentHop,
 	TUserConfig,
+	TReconstructAndSpendOutputsReq,
 } from './utils/types';
 import { extractPaymentRequest } from './utils/helpers';
 
@@ -1142,6 +1143,46 @@ class LDK {
 			return ok({ ...res, timestamp: Math.round(res.timestamp) });
 		} catch (e) {
 			this.writeErrorToLog('readFromFile', e);
+			return err(e);
+		}
+	}
+
+	/**
+	 * Rebuilds a transaction when the spendable output was not previously saved.
+	 * Returns the raw transaction hex.
+	 * @param outputScriptPubKey
+	 * @param outputValue
+	 * @param outpointTxId
+	 * @param outpointIndex
+	 * @param feeRate
+	 * @param changeDestinationScript
+	 * @returns {Promise<Ok<string> | Err<unknown>>}
+	 */
+	async reconstructAndSpendOutputs({
+		outputScriptPubKey,
+		outputValue,
+		outpointTxId,
+		outpointIndex,
+		feeRate,
+		changeDestinationScript,
+	}: TReconstructAndSpendOutputsReq): Promise<Result<string>> {
+		if (Platform.OS !== 'ios') {
+			return err('Currently only working on iOS');
+		}
+
+		try {
+			const res = await NativeLDK.reconstructAndSpendOutputs(
+				outputScriptPubKey,
+				outputValue,
+				outpointTxId,
+				outpointIndex,
+				feeRate,
+				changeDestinationScript,
+			);
+			this.writeDebugToLog('reconstructAndSpendOutputs', res);
+			return ok(res);
+		} catch (e) {
+			this.writeErrorToLog('reconstructAndSpendOutputs', e);
 			return err(e);
 		}
 	}

--- a/lib/src/utils/helpers.ts
+++ b/lib/src/utils/helpers.ts
@@ -265,3 +265,38 @@ export const promiseTimeout = <T>(
 		return result;
 	});
 };
+
+type TFindOutputsFromRawTxsRes = {
+	outputScriptPubKey: string;
+	outputValue: number;
+	outpointTxId: string;
+	outpointIndex: number;
+};
+export const findOutputsFromRawTxs = (
+	rawTxs: string[],
+	txId: string,
+	index: number,
+): TFindOutputsFromRawTxsRes | undefined => {
+	let result: TFindOutputsFromRawTxsRes | undefined;
+	for (const hexTx of rawTxs) {
+		const tx = bitcoin.Transaction.fromHex(hexTx);
+		if (tx.getId() !== txId) {
+			continue;
+		}
+
+		if (tx.outs.length <= index) {
+			continue;
+		}
+
+		const output = tx.outs[index];
+
+		result = {
+			outputScriptPubKey: output.script.toString('hex'),
+			outputValue: output.value,
+			outpointTxId: txId,
+			outpointIndex: index,
+		};
+	}
+
+	return result;
+};

--- a/lib/src/utils/types.ts
+++ b/lib/src/utils/types.ts
@@ -526,3 +526,12 @@ export type TBroadcastTransaction = (rawTx: string) => Promise<any>;
 export type TGetFees = () => Promise<TFeeUpdateReq>;
 
 export type TVout = { hex: string; n: number; value: number };
+
+export type TReconstructAndSpendOutputsReq = {
+	outputScriptPubKey: string;
+	outputValue: number;
+	outpointTxId: string;
+	outpointIndex: number;
+	feeRate: number;
+	changeDestinationScript: string;
+};

--- a/lib/src/utils/types.ts
+++ b/lib/src/utils/types.ts
@@ -431,6 +431,7 @@ export enum ELdkFiles {
 	confirmed_outputs = 'confirmed_outputs.json',
 	broadcasted_transactions = 'broadcasted_transactions.json',
 	payment_ids = 'payment_ids.json',
+	spendable_outputs = 'spendable_outputs.json',
 }
 
 export enum ELdkData {
@@ -442,6 +443,7 @@ export enum ELdkData {
 	broadcasted_transactions = 'broadcasted_transactions',
 	payment_ids = 'payment_ids',
 	timestamp = 'timestamp',
+	spendable_outputs = 'spendable_outputs',
 }
 
 export type TLdkData = {
@@ -453,6 +455,7 @@ export type TLdkData = {
 	[ELdkData.broadcasted_transactions]: TLdkBroadcastedTransactions;
 	[ELdkData.payment_ids]: TLdkPaymentIds;
 	[ELdkData.timestamp]: number;
+	[ELdkData.spendable_outputs]: TLdkSpendableOutputs;
 };
 
 export type TAccountBackup = {
@@ -472,6 +475,8 @@ export type TLdkBroadcastedTransactions = string[];
 
 export type TLdkPaymentIds = string[];
 
+export type TLdkSpendableOutputs = string[];
+
 export const DefaultLdkDataShape: TLdkData = {
 	[ELdkData.channel_manager]: '',
 	[ELdkData.channel_monitors]: {},
@@ -481,6 +486,7 @@ export const DefaultLdkDataShape: TLdkData = {
 	[ELdkData.broadcasted_transactions]: [],
 	[ELdkData.payment_ids]: [],
 	[ELdkData.timestamp]: 0,
+	[ELdkData.spendable_outputs]: [],
 };
 
 export type TAvailableNetworks =


### PR DESCRIPTION
- Caches all outputs before creating spending tx
- Recovery function that attempts to re spend all cached outputs and then reconstruct outputs not cached in previous versions based on cached transactions that failed to broadcast due to low fee bug
- Improved logging
- Pay with timeout of 60s instead of 3 attempts