### PR TITLE
Android reconstructAndSpendOutputs endianness fix

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -302,7 +302,7 @@ PODS:
   - React-jsinspector (0.70.6)
   - React-logger (0.70.6):
     - glog
-  - react-native-ldk (0.0.89):
+  - react-native-ldk (0.0.93):
     - React
   - react-native-randombytes (3.6.1):
     - React-Core
@@ -593,7 +593,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: b4a65947391c658450151275aa406f2b8263178f
   React-jsinspector: 60769e5a0a6d4b32294a2456077f59d0266f9a8b
   React-logger: 1623c216abaa88974afce404dc8f479406bbc3a0
-  react-native-ldk: 58ed077970033a7017a290b4a5ec6189c70ebb08
+  react-native-ldk: 092ee2346aedc13bac062e1755ede58933967cac
   react-native-randombytes: 421f1c7d48c0af8dbcd471b0324393ebf8fe7846
   react-native-tcp-socket: c1b7297619616b4c9caae6889bcb0aba78086989
   React-perflogger: 8c79399b0500a30ee8152d0f9f11beae7fc36595

--- a/lib/android/src/main/java/com/reactnativeldk/LdkModule.kt
+++ b/lib/android/src/main/java/com/reactnativeldk/LdkModule.kt
@@ -975,7 +975,7 @@ class LdkModule(reactContext: ReactApplicationContext) : ReactContextBaseJavaMod
         keysManager ?: return handleReject(promise, LdkErrors.init_keys_manager)
 
         val output = TxOut(outputValue.toLong(), outputScriptPubKey.hexa())
-        val outpoint = OutPoint.of(outpointTxId.hexa(), outpointIndex.toInt().toShort())
+        val outpoint = OutPoint.of(outpointTxId.hexa().reversedArray(), outpointIndex.toInt().toShort())
         val descriptor = SpendableOutputDescriptor.static_output(outpoint, output)
 
         val ldkDescriptors: MutableList<SpendableOutputDescriptor> = arrayListOf()

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@synonymdev/react-native-ldk",
   "title": "React Native LDK",
-  "version": "0.0.91",
+  "version": "0.0.93",
   "description": "React Native wrapper for LDK",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
- Reverse outpoint tx ID when spending stuck outputs
- Version bump