### PR TITLE
Fixes failed first payments

### DIFF
--- a/lib/android/src/main/java/com/reactnativeldk/LdkModule.kt
+++ b/lib/android/src/main/java/com/reactnativeldk/LdkModule.kt
@@ -608,7 +608,7 @@ class LdkModule(reactContext: ReactApplicationContext) : ReactContextBaseJavaMod
     }
 
     @ReactMethod
-    fun pay(paymentRequest: String, amountSats: Double, promise: Promise) {
+    fun pay(paymentRequest: String, amountSats: Double, timeoutSeconds: Double, promise: Promise) {
         channelManager ?: return handleReject(promise, LdkErrors.init_channel_manager)
 
         val invoiceParse = Invoice.from_str(paymentRequest)
@@ -630,8 +630,8 @@ class LdkModule(reactContext: ReactApplicationContext) : ReactContextBaseJavaMod
         }
 
         val res = if (isZeroValueInvoice)
-            UtilMethods.pay_zero_value_invoice(invoice, amountSats.toLong() * 1000, Retry.timeout(60), channelManager) else
-            UtilMethods.pay_invoice(invoice, Retry.timeout(60), channelManager)
+            UtilMethods.pay_zero_value_invoice(invoice, amountSats.toLong() * 1000, Retry.timeout(timeoutSeconds.toLong()), channelManager) else
+            UtilMethods.pay_invoice(invoice, Retry.timeout(timeoutSeconds.toLong()), channelManager)
         if (res.is_ok) {
             return handleResolve(promise, LdkCallbackResponses.invoice_payment_success)
         }

--- a/lib/ios/Ldk.m
+++ b/lib/ios/Ldk.m
@@ -106,6 +106,7 @@ RCT_EXTERN_METHOD(decode:(NSString *)paymentRequest
                   reject:(RCTPromiseRejectBlock)reject)
 RCT_EXTERN_METHOD(pay:(NSString *)paymentRequest
                   amountSats:(NSInteger *)amountSats
+                  timeoutSeconds:(NSInteger *)timeoutSeconds
                   resolve:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject)
 RCT_EXTERN_METHOD(payWithRoute:(NSArray *)route

--- a/lib/ios/Ldk.swift
+++ b/lib/ios/Ldk.swift
@@ -690,7 +690,7 @@ class Ldk: NSObject {
     }
     
     @objc
-    func pay(_ paymentRequest: NSString, amountSats: NSInteger, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+    func pay(_ paymentRequest: NSString, amountSats: NSInteger, timeoutSeconds: NSInteger, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
         guard let channelManager = channelManager else {
             return handleReject(reject, .init_channel_manager)
         }
@@ -712,8 +712,8 @@ class Ldk: NSObject {
         }
         
         let res = isZeroValueInvoice ?
-        Bindings.payZeroValueInvoice(invoice: invoice, amountMsats: UInt64(amountSats * 1000), retryStrategy: .initWithTimeout(a: 60), channelmanager: channelManager) :
-        Bindings.payInvoice(invoice: invoice, retryStrategy: .initWithTimeout(a: 60), channelmanager: channelManager)
+        Bindings.payZeroValueInvoice(invoice: invoice, amountMsats: UInt64(amountSats * 1000), retryStrategy: .initWithTimeout(a: UInt64(timeoutSeconds)), channelmanager: channelManager) :
+        Bindings.payInvoice(invoice: invoice, retryStrategy: .initWithTimeout(a: UInt64(timeoutSeconds)), channelmanager: channelManager)
         
         if res.isOk() {
             return resolve(Data(res.getValue() ?? []).hexEncodedString())

--- a/lib/src/ldk.ts
+++ b/lib/src/ldk.ts
@@ -564,6 +564,7 @@ class LDK {
 	async pay({
 		paymentRequest: anyPaymentRequest,
 		amountSats,
+		timeout = 20000,
 	}: TPaymentReq): Promise<Result<string>> {
 		const paymentRequest = extractPaymentRequest(anyPaymentRequest);
 
@@ -576,7 +577,12 @@ class LDK {
 		}
 
 		try {
-			const res = await NativeLDK.pay(paymentRequest, amountSats || 0);
+			const timeoutSeconds = timeout / 1000; //Rust demands seconds
+			const res = await NativeLDK.pay(
+				paymentRequest,
+				amountSats || 0,
+				timeoutSeconds,
+			);
 			this.writeDebugToLog('pay');
 			return ok(res);
 		} catch (e) {

--- a/lib/src/lightning-manager.ts
+++ b/lib/src/lightning-manager.ts
@@ -935,6 +935,10 @@ class LightningManager {
 				`ldk.pay() called with hard timeout of ${timeout}ms`,
 			);
 
+			if (timeout < 1000) {
+				return resolve(err('Timeout must be at least 1000ms.'));
+			}
+
 			this.subscribeToPaymentResponses(resolve);
 
 			let payResponse: Result<string> | undefined = await ldk.pay({

--- a/lib/src/lightning-manager.ts
+++ b/lib/src/lightning-manager.ts
@@ -920,43 +920,46 @@ class LightningManager {
 	}: TPaymentTimeoutReq): Promise<Result<TChannelManagerPaymentSent>> => {
 		return promiseTimeout(
 			timeout,
-			this.subscribeAndPay({ paymentRequest, amountSats }),
+			this.subscribeAndPay({ paymentRequest, amountSats, timeout }),
 		);
 	};
 
 	private subscribeAndPay = async ({
 		paymentRequest,
 		amountSats,
+		timeout = 20000,
 	}: TPaymentReq): Promise<Result<TChannelManagerPaymentSent>> => {
 		return new Promise(async (resolve) => {
-			this.subscribeToPaymentResponses(resolve).then();
+			await ldk.writeToLogFile(
+				'debug',
+				`ldk.pay() called with hard timeout of ${timeout}ms`,
+			);
+
+			this.subscribeToPaymentResponses(resolve);
 
 			let payResponse: Result<string> | undefined = await ldk.pay({
 				paymentRequest,
 				amountSats,
+				timeout,
 			});
 
 			await ldk.writeToLogFile(
 				'debug',
-				payResponse.isOk() ? `ldk.pay() success ${payResponse.value}` : '',
+				payResponse.isOk()
+					? `ldk.pay() success (pending callbacks) Payment ID: ${payResponse.value}`
+					: `ldk.pay() error ${payResponse.error.message}.`,
 			);
-
-			//Quickly retry with default invoice payer method
-			// if (!payResponse.isOk()) {
-			// 	payResponse = await ldk.pay({
-			// 		paymentRequest,
-			// 		amountSats,
-			// 	});
-			// }
 
 			if (!payResponse) {
 				this.unsubscribeFromPaymentSubscriptions();
 				return resolve(err('Unable to pay the provided lightning invoice.'));
 			}
+
 			if (payResponse.isErr()) {
 				this.unsubscribeFromPaymentSubscriptions();
 				return resolve(err(payResponse.error.message));
 			}
+
 			//Save payment ids to file on payResponse success.
 			await this.appendLdkPaymentId(payResponse.value);
 		});
@@ -964,29 +967,27 @@ class LightningManager {
 
 	/**
 	 * Subscribes to outgoing lightning payments.
-	 * @returns {Promise<Result<TChannelManagerPaymentSent>>}
+	 * @returns {void}
 	 */
-	private subscribeToPaymentResponses = async (resolve: any): Promise<void> => {
+	private subscribeToPaymentResponses = (resolve: any): void => {
 		this.pathFailedSubscription = ldk.onEvent(
 			EEventTypes.channel_manager_payment_path_failed,
 			async (res: TChannelManagerPaymentPathFailed) => {
-				this.unsubscribeFromPaymentSubscriptions();
-				const abandonPaymentRes = await ldk.abandonPayment(res.payment_id);
-				if (abandonPaymentRes.isOk()) {
+				if (res.payment_failed_permanently) {
+					//Only resolve on a permanent failure, bindings will keep retrying otherwise.
+					this.unsubscribeFromPaymentSubscriptions();
 					this.removeLdkPaymentId(res.payment_id).then();
+					//TODO return error message
+					return resolve(err('Payment path failed.'));
 				}
-				return resolve(err(res.payment_id));
 			},
 		);
 		this.paymentFailedSubscription = ldk.onEvent(
 			EEventTypes.channel_manager_payment_failed,
 			async (res: TChannelManagerPaymentFailed) => {
 				this.unsubscribeFromPaymentSubscriptions();
-				const abandonPaymentRes = await ldk.abandonPayment(res.payment_id);
-				if (abandonPaymentRes.isOk()) {
-					this.removeLdkPaymentId(res.payment_id).then();
-				}
-				return resolve(err(res.payment_id));
+				this.removeLdkPaymentId(res.payment_id).then();
+				return resolve(err('Payment failed'));
 			},
 		);
 		this.paymentSentSubscription = ldk.onEvent(

--- a/lib/src/utils/types.ts
+++ b/lib/src/utils/types.ts
@@ -270,6 +270,7 @@ export type TSpendOutputsReq = {
 export type TPaymentReq = {
 	paymentRequest: string;
 	amountSats?: number;
+	timeout?: number; //ms
 };
 
 export type TPaymentTimeoutReq = TPaymentReq & {


### PR DESCRIPTION
- Passes hard timeout to bindings so payments are given up at the same time as the JS times outs. This fixes an issue where people were having successful payments and the UI would say it was a failure and never add it to the tx list.
- When subscribing to outgoing payment events only resolve with an error if `payment_failed_permanently` is `true` As to not prematurely abandon payments that can be auto retried. This fixes an issue where first attempts at paying an invoice failed but manually retrying worked.