### PR TITLE
feat: add jest mock

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,3 +52,15 @@ yarn android
 - Use latest LDKFramework.xcframework from [ldk-swift](https://github.com/lightningdevkit/ldk-swift/releases) and place in lib/ios.
   - To get `pod install` working you might have to open the `LDKFramework.xcframework` directory, delete non ios frameworks and remove all references to deleted frameworks inside `LDKFramework.xcframework/Info.plist`.
 - Update Swift and Kotlin code if there are any breaking changes.
+
+## How to test your code
+
+Because it's a native module, you need to mock this package.
+
+The package provides a default mock you may use in your \_\_mocks\_\_/@synonymdev/react-native-ldk.js or jest.setup.js.
+
+```ts
+import * as mockLDK from '@synonymdev/react-native-ldk/dist/mock';
+
+jest.mock('@synonymdev/react-native-ldk', () => mockLDK);
+```

--- a/lib/src/index.ts
+++ b/lib/src/index.ts
@@ -1,4 +1,3 @@
-import lm from './lightning-manager';
-
 export * from './utils/types';
-export default lm;
+export { default } from './lightning-manager';
+export { default as ldk } from './ldk';

--- a/lib/src/mock.ts
+++ b/lib/src/mock.ts
@@ -1,0 +1,57 @@
+export * from './utils/types';
+
+const noop = (): void => {};
+
+export const ldk = {
+	ldkEvent: noop,
+	logListeners: [],
+	reset: noop,
+};
+
+export default {
+	getBestBlock: noop,
+	getTransactionData: noop,
+	getTransactionPosition: noop,
+	getAddress: noop,
+	getScriptPubKeyHistory: noop,
+	getFees: noop,
+	broadcastTransaction: noop,
+	addPeer: noop,
+	removePeer: noop,
+	getPeers: noop,
+	importAccount: noop,
+	backupAccount: noop,
+	payWithTimeout: noop,
+	subscribeAndPay: noop,
+	subscribeToPaymentResponses: noop,
+	unsubscribeFromPaymentSubscriptions: noop,
+	getChangeDestinationScript: noop,
+	getLdkConfirmedTxs: noop,
+	getLdkPaymentIds: noop,
+	removeLdkPaymentId: noop,
+	appendLdkPaymentId: noop,
+	getLdkConfirmedOutputs: noop,
+	getLdkSpendableOutputs: noop,
+	saveConfirmedTxs: noop,
+	saveConfirmedOutputs: noop,
+	saveBroadcastedTxs: noop,
+	saveLdkPeerData: noop,
+
+	currentBlock: {
+		height: 1,
+		hex: 'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff',
+		hash: 'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff',
+	},
+	watchTxs: [],
+	watchOutputs: [],
+	account: {
+		name: 'wallet0bitcoinldkaccount',
+		seed: 'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff',
+	},
+	backupSubscriptions: {},
+	backupSubscriptionsId: 1,
+	backupSubscriptionsDebounceTimer: 1,
+	network: 'mainnet',
+	baseStoragePath: '/ldk/',
+	logFilePath: '/ldk/wallet0bitcoinldkaccount/logs/1.log',
+};


### PR DESCRIPTION
- add mock that can be used in enviroments, like jest, were you can't use RN.
- ldk can now be directly imported from root package, this help making mocking easy