### PR TITLE
feat: Add payments claimed to storage

### DIFF
--- a/example/App.tsx
+++ b/example/App.tsx
@@ -414,7 +414,7 @@ const App = (): ReactElement => {
 						title={'Get claimed payments'}
 						onPress={async (): Promise<void> => {
 							setMessage('Getting all LDK payments...');
-							const res = await lm.getLdkPaymentsClaimed()
+							const res = await lm.getLdkPaymentsClaimed();
 							setMessage(JSON.stringify(res));
 						}}
 					/>

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -411,6 +411,15 @@ const App = (): ReactElement => {
 					/>
 
 					<Button
+						title={'Get claimed payments'}
+						onPress={async (): Promise<void> => {
+							setMessage('Getting all LDK payments...');
+							const res = await lm.getLdkPaymentsClaimed()
+							setMessage(JSON.stringify(res));
+						}}
+					/>
+
+					<Button
 						title={'Create invoice'}
 						onPress={async (): Promise<void> => {
 							const createInvoice = async (

--- a/lib/src/lightning-manager.ts
+++ b/lib/src/lightning-manager.ts
@@ -1139,7 +1139,9 @@ class LightningManager {
 	 * @param payment {@link TChannelManagerClaim}
 	 * @returns void
 	 */
-	private appendLdkPaymentsClaimed = async (payment: TChannelManagerClaim): Promise<void> => {
+	private appendLdkPaymentsClaimed = async (
+		payment: TChannelManagerClaim,
+	): Promise<void> => {
 		let paymentsClaimed = await this.getLdkPaymentsClaimed();
 		if (paymentsClaimed.includes(payment)) {
 			return;
@@ -1148,7 +1150,7 @@ class LightningManager {
 		paymentsClaimed.push(payment);
 		await ldk.writeToFile({
 			fileName: ELdkFiles.payments_claimed,
-			content: JSON.stringify(paymentsClaimed)
+			content: JSON.stringify(paymentsClaimed),
 		});
 	};
 
@@ -1158,16 +1160,13 @@ class LightningManager {
 	 */
 	getLdkPaymentsClaimed = async (): Promise<TChannelManagerClaim[]> => {
 		const res = await ldk.readFromFile({
-			fileName: ELdkFiles.payments_claimed
-		})
+			fileName: ELdkFiles.payments_claimed,
+		});
 		if (res.isOk()) {
-			return parseData(
-				res.value.content,
-				DefaultLdkDataShape.payments_claimed
-			)
+			return parseData(res.value.content, DefaultLdkDataShape.payments_claimed);
 		}
-		return DefaultLdkDataShape.payments_claimed
-	}
+		return DefaultLdkDataShape.payments_claimed;
+	};
 
 	/**
 	 * Returns previously confirmed outputs from storage.
@@ -1600,9 +1599,11 @@ class LightningManager {
 		console.log(`onChannelManagerDiscardFunding: ${JSON.stringify(res)}`); //TODO
 	}
 
-	private async onChannelManagerPaymentClaimed(res: TChannelManagerClaim): Promise<void> {
+	private async onChannelManagerPaymentClaimed(
+		res: TChannelManagerClaim,
+	): Promise<void> {
 		// Payment Received/Invoice Paid.
-		await this.appendLdkPaymentsClaimed(res)
+		await this.appendLdkPaymentsClaimed(res);
 		console.log(`onChannelManagerPaymentClaimed: ${JSON.stringify(res)}`);
 		this.syncLdk().then();
 	}

--- a/lib/src/utils/types.ts
+++ b/lib/src/utils/types.ts
@@ -428,6 +428,7 @@ export enum ELdkFiles {
 	broadcasted_transactions = 'broadcasted_transactions.json',
 	payment_ids = 'payment_ids.json',
 	spendable_outputs = 'spendable_outputs.json',
+	payments_claimed = 'payments_claimed.json' // JSON file saved from JS
 }
 
 export enum ELdkData {
@@ -440,6 +441,7 @@ export enum ELdkData {
 	payment_ids = 'payment_ids',
 	timestamp = 'timestamp',
 	spendable_outputs = 'spendable_outputs',
+	payments_claimed = 'payments_claimed'
 }
 
 export type TLdkData = {
@@ -452,6 +454,7 @@ export type TLdkData = {
 	[ELdkData.payment_ids]: TLdkPaymentIds;
 	[ELdkData.timestamp]: number;
 	[ELdkData.spendable_outputs]: TLdkSpendableOutputs;
+	[ELdkData.payments_claimed]: TChannelManagerClaim[]
 };
 
 export type TAccountBackup = {
@@ -483,6 +486,7 @@ export const DefaultLdkDataShape: TLdkData = {
 	[ELdkData.payment_ids]: [],
 	[ELdkData.timestamp]: 0,
 	[ELdkData.spendable_outputs]: [],
+	[ELdkData.payments_claimed]: []
 };
 
 export type TAvailableNetworks =

--- a/lib/src/utils/types.ts
+++ b/lib/src/utils/types.ts
@@ -428,7 +428,7 @@ export enum ELdkFiles {
 	broadcasted_transactions = 'broadcasted_transactions.json',
 	payment_ids = 'payment_ids.json',
 	spendable_outputs = 'spendable_outputs.json',
-	payments_claimed = 'payments_claimed.json' // JSON file saved from JS
+	payments_claimed = 'payments_claimed.json', // JSON file saved from JS
 }
 
 export enum ELdkData {
@@ -441,7 +441,7 @@ export enum ELdkData {
 	payment_ids = 'payment_ids',
 	timestamp = 'timestamp',
 	spendable_outputs = 'spendable_outputs',
-	payments_claimed = 'payments_claimed'
+	payments_claimed = 'payments_claimed',
 }
 
 export type TLdkData = {
@@ -454,7 +454,7 @@ export type TLdkData = {
 	[ELdkData.payment_ids]: TLdkPaymentIds;
 	[ELdkData.timestamp]: number;
 	[ELdkData.spendable_outputs]: TLdkSpendableOutputs;
-	[ELdkData.payments_claimed]: TChannelManagerClaim[]
+	[ELdkData.payments_claimed]: TChannelManagerClaim[];
 };
 
 export type TAccountBackup = {
@@ -486,7 +486,7 @@ export const DefaultLdkDataShape: TLdkData = {
 	[ELdkData.payment_ids]: [],
 	[ELdkData.timestamp]: 0,
 	[ELdkData.spendable_outputs]: [],
-	[ELdkData.payments_claimed]: []
+	[ELdkData.payments_claimed]: [],
 };
 
 export type TAvailableNetworks =


### PR DESCRIPTION
Links to issue [114](https://github.com/synonymdev/react-native-ldk/issues/114)

This PR adds claimed payments to storage in `{baseStoragePath}/payments_claimed.json` 

Would like feedback on if the strategy for storing transactions is correct. Could possibly be a parameter to `lm.start()` where it could be a read/write interface for developers to choose a storage strategy.