### PR TITLE
feat(lightning): Implement Reorg Checks

### DIFF
--- a/example/App.tsx
+++ b/example/App.tsx
@@ -500,19 +500,6 @@ const App = (): ReactElement => {
 					/>
 
 					<Button
-						title={'Build route and pay'}
-						onPress={async (): Promise<void> => {
-							const paymentRequest = await Clipboard.getString();
-							const payRes = await ldk.payWithRoute({ paymentRequest });
-							if (payRes.isErr()) {
-								return setMessage(payRes.error.message);
-							}
-
-							setMessage(payRes.value);
-						}}
-					/>
-
-					<Button
 						title={'Get network graph nodes'}
 						onPress={async (): Promise<void> => {
 							const nodesRes = await ldk.networkGraphListNodeIds();

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -302,7 +302,7 @@ PODS:
   - React-jsinspector (0.70.6)
   - React-logger (0.70.6):
     - glog
-  - react-native-ldk (0.0.97):
+  - react-native-ldk (0.0.98):
     - React
   - react-native-randombytes (3.6.1):
     - React-Core
@@ -593,7 +593,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: b4a65947391c658450151275aa406f2b8263178f
   React-jsinspector: 60769e5a0a6d4b32294a2456077f59d0266f9a8b
   React-logger: 1623c216abaa88974afce404dc8f479406bbc3a0
-  react-native-ldk: 38eb5291779f3ef181fd6472e7cd5ebf15797f8d
+  react-native-ldk: 0b2b9c3e57c80b19d94ec306f49765b29530758e
   react-native-randombytes: 421f1c7d48c0af8dbcd471b0324393ebf8fe7846
   react-native-tcp-socket: c1b7297619616b4c9caae6889bcb0aba78086989
   React-perflogger: 8c79399b0500a30ee8152d0f9f11beae7fc36595
@@ -618,4 +618,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: 686e912f33d09c328c075738266ee797003d369e
 
-COCOAPODS: 1.12.0
+COCOAPODS: 1.12.1

--- a/lib/ios/Ldk.m
+++ b/lib/ios/Ldk.m
@@ -112,17 +112,6 @@ RCT_EXTERN_METHOD(pay:(NSString *)paymentRequest
                   timeoutSeconds:(NSInteger *)timeoutSeconds
                   resolve:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject)
-RCT_EXTERN_METHOD(payWithRoute:(NSArray *)route
-                  destinationNodeId:(NSString *)destinationNodeId
-                  amountSats:(NSInteger *)amountSats
-                  cltvExpiryDelta:(NSInteger *)cltvExpiryDelta
-                  paymentHash:(NSString *)paymentHash
-                  paymentSecret:(NSString *)paymentSecret
-                  resolve:(RCTPromiseResolveBlock)resolve
-                  reject:(RCTPromiseRejectBlock)reject)
-RCT_EXTERN_METHOD(payWithRoute2:(NSString *)payReq
-                  resolve:(RCTPromiseResolveBlock)resolve
-                  reject:(RCTPromiseRejectBlock)reject)
 RCT_EXTERN_METHOD(abandonPayment:(NSString *)paymentId
                   resolve:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject)

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@synonymdev/react-native-ldk",
   "title": "React Native LDK",
-  "version": "0.0.97",
+  "version": "0.0.98",
   "description": "React Native wrapper for LDK",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/lib/src/mock.ts
+++ b/lib/src/mock.ts
@@ -42,6 +42,7 @@ export default {
 		hex: 'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff',
 		hash: 'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff',
 	},
+	unconfirmedTxs: [],
 	watchTxs: [],
 	watchOutputs: [],
 	account: {

--- a/lib/src/utils/types.ts
+++ b/lib/src/utils/types.ts
@@ -242,10 +242,6 @@ export type TSetTxConfirmedReq = {
 	height: number;
 };
 
-export type TSetTxUnconfirmedReq = {
-	txId: string;
-};
-
 export type TCloseChannelReq = {
 	channelId: string;
 	counterPartyNodeId: string;
@@ -410,7 +406,9 @@ export const DefaultTransactionDataShape: TTransactionData = {
 	vout: [],
 };
 
-export type TGetTransactionData = (txid: string) => Promise<TTransactionData>;
+export type TGetTransactionData = (
+	txid: string,
+) => Promise<TTransactionData | undefined>;
 export type TGetTransactionPosition = (params: {
 	tx_hash: string;
 	height: number;
@@ -422,10 +420,7 @@ export enum ELdkFiles {
 	channel_manager = 'channel_manager.bin', //Serialised rust object
 	channels = 'channels', //Path containing multiple files of serialised channels
 	peers = 'peers.json', //JSON file saved from JS
-	watch_transactions = 'watch_transactions.json', //JSON file saved from JS
-	watch_outputs = 'watch_outputs.json', //JSON file saved from JS
-	confirmed_transactions = 'confirmed_transactions.json',
-	confirmed_outputs = 'confirmed_outputs.json',
+	unconfirmed_transactions = 'unconfirmed_transactions.json',
 	broadcasted_transactions = 'broadcasted_transactions.json',
 	payment_ids = 'payment_ids.json',
 	spendable_outputs = 'spendable_outputs.json',
@@ -435,8 +430,7 @@ export enum ELdkData {
 	channel_manager = 'channel_manager',
 	channel_monitors = 'channel_monitors',
 	peers = 'peers',
-	confirmed_transactions = 'confirmed_transactions',
-	confirmed_outputs = 'confirmed_outputs',
+	unconfirmed_transactions = 'unconfirmed_transactions',
 	broadcasted_transactions = 'broadcasted_transactions',
 	payment_ids = 'payment_ids',
 	timestamp = 'timestamp',
@@ -447,8 +441,7 @@ export type TLdkData = {
 	[ELdkData.channel_manager]: string;
 	[ELdkData.channel_monitors]: { [key: string]: string };
 	[ELdkData.peers]: TLdkPeers;
-	[ELdkData.confirmed_transactions]: TLdkConfirmedTransactions;
-	[ELdkData.confirmed_outputs]: TLdkConfirmedOutputs;
+	[ELdkData.unconfirmed_transactions]: TLdkUnconfirmedTransactions;
 	[ELdkData.broadcasted_transactions]: TLdkBroadcastedTransactions;
 	[ELdkData.payment_ids]: TLdkPaymentIds;
 	[ELdkData.timestamp]: number;
@@ -464,9 +457,12 @@ export type TAccountBackup = {
 
 export type TLdkPeers = TPeer[];
 
-export type TLdkConfirmedTransactions = string[];
+export type TLdkUnconfirmedTransaction = TTransactionData & {
+	txid: string;
+	script_pubkey: string;
+};
 
-export type TLdkConfirmedOutputs = string[];
+export type TLdkUnconfirmedTransactions = TLdkUnconfirmedTransaction[];
 
 export type TLdkBroadcastedTransactions = string[];
 
@@ -478,8 +474,7 @@ export const DefaultLdkDataShape: TLdkData = {
 	[ELdkData.channel_manager]: '',
 	[ELdkData.channel_monitors]: {},
 	[ELdkData.peers]: [],
-	[ELdkData.confirmed_transactions]: [],
-	[ELdkData.confirmed_outputs]: [],
+	[ELdkData.unconfirmed_transactions]: [],
 	[ELdkData.broadcasted_transactions]: [],
 	[ELdkData.payment_ids]: [],
 	[ELdkData.timestamp]: 0,


### PR DESCRIPTION
This PR:
- Implements reorg checks where needed.
- Sets tx as unconfirmed when a reorg or missing tx is detected.
- Adds `unconfirmedTxs` to `lightning-manager.ts`.
- Removes `confirmedTxs` from `lightning-manager.ts` along with its corresponding checks.
- Removes leftover `payWithRoute` methods.
- Bumps version to `0.0.98`.

When a watch transaction or watch output is seen as having one or more confirmation it is added to the `unconfirmedTxs` array. These txs will continue to be monitored until they reach 6 or more confirmations. If at any point a transaction is reorg'd by having a lower height than the previous known height or is no longer in the chain/mempool `ldk.setTxUnconfirmed` is called. In these rare scenarios, LDK will typically force-close and the user will have to wait roughly 143-150 blocks for their funds to be returned.