### PR TITLE
Native transaction persistence

### DIFF
--- a/example/App.tsx
+++ b/example/App.tsx
@@ -413,8 +413,16 @@ const App = (): ReactElement => {
 					<Button
 						title={'Get claimed payments'}
 						onPress={async (): Promise<void> => {
-							setMessage('Getting all LDK payments...');
+							setMessage('Getting all claimed payments...');
 							const res = await lm.getLdkPaymentsClaimed();
+							setMessage(JSON.stringify(res));
+						}}
+					/>
+					<Button
+						title={'Get sent payments'}
+						onPress={async (): Promise<void> => {
+							setMessage('Getting all sent payments...');
+							const res = await lm.getLdkPaymentsSent();
 							setMessage(JSON.stringify(res));
 						}}
 					/>

--- a/lib/android/src/main/java/com/reactnativeldk/Helpers.kt
+++ b/lib/android/src/main/java/com/reactnativeldk/Helpers.kt
@@ -1,5 +1,6 @@
 package com.reactnativeldk
 import com.facebook.react.bridge.*
+import org.json.JSONObject
 import org.ldk.enums.Currency
 import org.ldk.enums.Network
 import org.ldk.structs.*
@@ -381,4 +382,18 @@ fun getNetwork(chain: String): Pair<Network, Currency> {
         "mainnet" -> Pair(Network.LDKNetwork_Bitcoin, Currency.LDKCurrency_Bitcoin)
         else -> Pair(Network.LDKNetwork_Bitcoin, Currency.LDKCurrency_Bitcoin)
     }
+}
+
+fun mergeObj(obj1: JSONObject, obj2: HashMap<String, Any>): HashMap<String, Any> {
+    val newObj = HashMap<String, Any>()
+
+    obj1.keys().forEach { key ->
+        newObj[key] = obj1[key]
+    }
+
+    obj2.keys.forEach { key ->
+        newObj[key] = obj2[key]!!
+    }
+
+    return newObj
 }

--- a/lib/android/src/main/java/com/reactnativeldk/LdkModule.kt
+++ b/lib/android/src/main/java/com/reactnativeldk/LdkModule.kt
@@ -13,6 +13,7 @@ import org.ldk.impl.bindings.get_ldk_version
 import org.ldk.structs.*
 import org.ldk.structs.Result_InvoiceParseOrSemanticErrorZ.Result_InvoiceParseOrSemanticErrorZ_OK
 import org.ldk.structs.Result_InvoiceSignOrCreationErrorZ.Result_InvoiceSignOrCreationErrorZ_OK
+import org.ldk.structs.Result_PaymentIdPaymentErrorZ.Result_PaymentIdPaymentErrorZ_OK
 import java.io.File
 import java.net.InetSocketAddress
 import java.nio.file.Files
@@ -113,6 +114,7 @@ enum class LdkFileNames(val fileName: String) {
     channel_manager("channel_manager.bin"),
     scorer("scorer.bin"),
     paymentsClaimed("payments_claimed.json"),
+    paymentsSent("payments_sent.json"),
 }
 
 class LdkModule(reactContext: ReactApplicationContext) : ReactContextBaseJavaModule(reactContext) {
@@ -685,6 +687,14 @@ class LdkModule(reactContext: ReactApplicationContext) : ReactContextBaseJavaMod
             UtilMethods.pay_zero_value_invoice(invoice, amountSats.toLong() * 1000, Retry.timeout(timeoutSeconds.toLong()), channelManager) else
             UtilMethods.pay_invoice(invoice, Retry.timeout(timeoutSeconds.toLong()), channelManager)
         if (res.is_ok) {
+            channelManagerPersister.persistPaymentSent(hashMapOf(
+                "payment_id" to (res as Result_PaymentIdPaymentErrorZ_OK).res.hexEncodedString(),
+                "payment_hash" to invoice.payment_hash().hexEncodedString(),
+                "amount_sat" to if (isZeroValueInvoice) amountSats.toLong() else ((invoice.amount_milli_satoshis() as Option_u64Z.Some).some.toInt() / 1000),
+                "unix_timestamp" to (System.currentTimeMillis() / 1000).toInt(),
+                "state" to "pending"
+            ))
+
             return handleResolve(promise, LdkCallbackResponses.invoice_payment_success)
         }
 

--- a/lib/android/src/main/java/com/reactnativeldk/LdkModule.kt
+++ b/lib/android/src/main/java/com/reactnativeldk/LdkModule.kt
@@ -111,7 +111,8 @@ enum class LdkCallbackResponses {
 enum class LdkFileNames(val fileName: String) {
     network_graph("network_graph.bin"),
     channel_manager("channel_manager.bin"),
-    scorer("scorer.bin")
+    scorer("scorer.bin"),
+    paymentsClaimed("payments_claimed.json"),
 }
 
 class LdkModule(reactContext: ReactApplicationContext) : ReactContextBaseJavaModule(reactContext) {

--- a/lib/ios/Classes/LdkLogger.swift
+++ b/lib/ios/Classes/LdkLogger.swift
@@ -33,6 +33,7 @@ class LdkLogger: Logger {
     override func log(record: Record) {
         let level = levelString(record.getLevel())
         
+        
         //Only when the JS code has set the log level to active
         if activeLevels[level] == true {
             LdkEventEmitter.shared.send(withEvent: .ldk_log, body: record.getArgs())

--- a/lib/ios/Helpers.swift
+++ b/lib/ios/Helpers.swift
@@ -445,3 +445,11 @@ func getNetwork(_ network: String) -> (Network, Currency)? {
         return nil
     }
 }
+
+func mergeObj(_ obj1: [String: Any], _ obj2: [String: Any]) -> [String: Any] {
+    var newObj = obj1
+    obj2.keys.forEach { key in
+        newObj[key] = obj2[key]
+    }
+    return newObj
+}

--- a/lib/ios/Ldk.swift
+++ b/lib/ios/Ldk.swift
@@ -95,6 +95,7 @@ enum LdkFileNames: String {
     case network_graph = "network_graph.bin"
     case channel_manager = "channel_manager.bin"
     case scorer = "scorer.bin"
+    case paymentsClaimed = "payments_claimed.json"
 }
 
 @objc(Ldk)
@@ -124,7 +125,6 @@ class Ldk: NSObject {
     var currentNetwork: NSString?
     var currentBlockchainTipHash: NSString?
     var currentBlockchainHeight: NSInteger?
-    
     
     //Static to be accessed from other classes
     static var accountStoragePath: URL?

--- a/lib/src/lightning-manager.ts
+++ b/lib/src/lightning-manager.ts
@@ -918,6 +918,7 @@ class LightningManager {
 					payment_ids: await this.getLdkPaymentIds(),
 					spendable_outputs: await this.getLdkSpendableOutputs(),
 					payments_claimed: await this.getLdkPaymentsClaimed(),
+					payments_sent: await this.getLdkPaymentsSent(),
 					timestamp: Date.now(),
 				},
 				package_version: require('../package.json').version,
@@ -1220,6 +1221,22 @@ class LightningManager {
 		}
 		return DefaultLdkDataShape.payments_claimed;
 	};
+
+	/**
+	 * Returns the payments sent in storage.
+	 * @returns {@link TChannelManagerPaymentSent[]}
+	 */
+	getLdkPaymentsSent = async (): Promise<TChannelManagerPaymentSent[]> => {
+		const res = await ldk.readFromFile({
+			fileName: ELdkFiles.payments_sent,
+		});
+		if (res.isOk()) {
+			return parseData(res.value.content, DefaultLdkDataShape.payments_sent);
+		}
+		return DefaultLdkDataShape.payments_sent;
+	};
+
+	//TODO Remove any stale payments from storage if stuck for 60min. No payment claim should be stuck that long.
 
 	private getLdkSpendableOutputs = async (): Promise<TLdkSpendableOutputs> => {
 		const res = await ldk.readFromFile({

--- a/lib/src/lightning-manager.ts
+++ b/lib/src/lightning-manager.ts
@@ -1208,26 +1208,6 @@ class LightningManager {
 	};
 
 	/**
-	 * Adds payment claimed to storage.
-	 * @param payment {@link TChannelManagerClaim}
-	 * @returns void
-	 */
-	private appendLdkPaymentsClaimed = async (
-		payment: TChannelManagerClaim,
-	): Promise<void> => {
-		let paymentsClaimed = await this.getLdkPaymentsClaimed();
-		if (paymentsClaimed.includes(payment)) {
-			return;
-		}
-
-		paymentsClaimed.push(payment);
-		await ldk.writeToFile({
-			fileName: ELdkFiles.payments_claimed,
-			content: JSON.stringify(paymentsClaimed),
-		});
-	};
-
-	/**
 	 * Returns the payments claimed in storage.
 	 * @returns {@link TChannelManagerClaim[]}
 	 */
@@ -1652,7 +1632,6 @@ class LightningManager {
 		res: TChannelManagerClaim,
 	): Promise<void> {
 		// Payment Received/Invoice Paid.
-		await this.appendLdkPaymentsClaimed(res);
 		console.log(`onChannelManagerPaymentClaimed: ${JSON.stringify(res)}`);
 		this.syncLdk().then();
 	}

--- a/lib/src/utils/types.ts
+++ b/lib/src/utils/types.ts
@@ -48,6 +48,8 @@ export type TChannelManagerFundingGenerationReady = {
 	value_satoshis: number;
 };
 
+type TPaymentState = 'pending' | 'failed' | 'successful';
+
 export type TChannelManagerClaim = {
 	payment_hash: string;
 	amount_sat: number;
@@ -55,14 +57,17 @@ export type TChannelManagerClaim = {
 	payment_secret: string;
 	spontaneous_payment_preimage: string;
 	unix_timestamp: number;
-	confirmed: boolean;
+	state: TPaymentState;
 };
 
 export type TChannelManagerPaymentSent = {
 	payment_id: string;
-	payment_preimage: string;
+	payment_preimage?: string;
 	payment_hash: string;
-	fee_paid_sat: number;
+	fee_paid_sat?: number;
+	amount_sat?: number;
+	unix_timestamp: number;
+	state: TPaymentState;
 };
 
 export type TChannelManagerOpenChannelRequest = {
@@ -427,6 +432,7 @@ export enum ELdkFiles {
 	payment_ids = 'payment_ids.json',
 	spendable_outputs = 'spendable_outputs.json',
 	payments_claimed = 'payments_claimed.json', // Written in swift/kotlin and read from JS
+	payments_sent = 'payments_sent.json', // Written in swift/kotlin and read from JS
 }
 
 export enum ELdkData {
@@ -439,6 +445,7 @@ export enum ELdkData {
 	timestamp = 'timestamp',
 	spendable_outputs = 'spendable_outputs',
 	payments_claimed = 'payments_claimed',
+	payments_sent = 'payments_sent',
 }
 
 export type TLdkData = {
@@ -451,6 +458,7 @@ export type TLdkData = {
 	[ELdkData.timestamp]: number;
 	[ELdkData.spendable_outputs]: TLdkSpendableOutputs;
 	[ELdkData.payments_claimed]: TChannelManagerClaim[];
+	[ELdkData.payments_sent]: TChannelManagerPaymentSent[];
 };
 
 export type TAccountBackup = {
@@ -485,6 +493,7 @@ export const DefaultLdkDataShape: TLdkData = {
 	[ELdkData.timestamp]: 0,
 	[ELdkData.spendable_outputs]: [],
 	[ELdkData.payments_claimed]: [],
+	[ELdkData.payments_sent]: [],
 };
 
 export type TAvailableNetworks =

--- a/lib/src/utils/types.ts
+++ b/lib/src/utils/types.ts
@@ -54,6 +54,7 @@ export type TChannelManagerClaim = {
 	payment_preimage: string;
 	payment_secret: string;
 	spontaneous_payment_preimage: string;
+	unix_timestamp: number;
 };
 
 export type TChannelManagerPaymentSent = {
@@ -419,12 +420,12 @@ export enum ELdkFiles {
 	seed = 'seed', //32 bytes of entropy saved natively
 	channel_manager = 'channel_manager.bin', //Serialised rust object
 	channels = 'channels', //Path containing multiple files of serialised channels
-	peers = 'peers.json', //JSON file saved from JS
+	peers = 'peers.json', //File saved from JS
 	unconfirmed_transactions = 'unconfirmed_transactions.json',
 	broadcasted_transactions = 'broadcasted_transactions.json',
 	payment_ids = 'payment_ids.json',
 	spendable_outputs = 'spendable_outputs.json',
-	payments_claimed = 'payments_claimed.json', // JSON file saved from JS
+	payments_claimed = 'payments_claimed.json', // Written in swift/kotlin and read from JS
 }
 
 export enum ELdkData {

--- a/lib/src/utils/types.ts
+++ b/lib/src/utils/types.ts
@@ -55,6 +55,7 @@ export type TChannelManagerClaim = {
 	payment_secret: string;
 	spontaneous_payment_preimage: string;
 	unix_timestamp: number;
+	confirmed: boolean;
 };
 
 export type TChannelManagerPaymentSent = {


### PR DESCRIPTION
- Changes claimed transactions to be written native in swift/kotlin as we often get missed react native events which results in the transactions happening but never being recorded in Bitkit. 
- Added sent payments persistence.
- Records pending and failed payments for claimed/sent. When an tx callback occurs those entries are updated with the correct state. This way users can see an incoming/outgoing payment in their activity list.