### PR TITLE
Option to force close channels on startup

### DIFF
--- a/example/App.tsx
+++ b/example/App.tsx
@@ -30,7 +30,11 @@ import lm, {
 	TChannelUpdate,
 } from '@synonymdev/react-native-ldk';
 import { peers } from './utils/constants';
-import { createNewAccount, getAddress } from './utils/helpers';
+import {
+	createNewAccount,
+	getAddress,
+	simulateStaleRestore,
+} from './utils/helpers';
 import RNFS from 'react-native-fs';
 
 let logSubscription: EmitterSubscription | undefined;
@@ -605,6 +609,17 @@ const App = (): ReactElement => {
 							setMessage(
 								`Successfully imported the following account: ${accountData}`,
 							);
+						}}
+					/>
+					<Button
+						title={'Simulate stale backup restore'}
+						onPress={async (): Promise<void> => {
+							try {
+								await simulateStaleRestore((msg) => setMessage(msg));
+							} catch (e) {
+								setMessage(e.message);
+								return;
+							}
 						}}
 					/>
 					<Button

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -302,7 +302,7 @@ PODS:
   - React-jsinspector (0.70.6)
   - React-logger (0.70.6):
     - glog
-  - react-native-ldk (0.0.98):
+  - react-native-ldk (0.0.99):
     - React
   - react-native-randombytes (3.6.1):
     - React-Core
@@ -593,7 +593,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: b4a65947391c658450151275aa406f2b8263178f
   React-jsinspector: 60769e5a0a6d4b32294a2456077f59d0266f9a8b
   React-logger: 1623c216abaa88974afce404dc8f479406bbc3a0
-  react-native-ldk: 0b2b9c3e57c80b19d94ec306f49765b29530758e
+  react-native-ldk: 175104646d32a4f52d82299c6981ad4bf91ad603
   react-native-randombytes: 421f1c7d48c0af8dbcd471b0324393ebf8fe7846
   react-native-tcp-socket: c1b7297619616b4c9caae6889bcb0aba78086989
   React-perflogger: 8c79399b0500a30ee8152d0f9f11beae7fc36595

--- a/example/utils/helpers.ts
+++ b/example/utils/helpers.ts
@@ -1,6 +1,10 @@
 import Keychain from 'react-native-keychain';
-import { TAccount, TAvailableNetworks } from '@synonymdev/react-native-ldk';
-import { getItem, setItem } from '../ldk';
+import {
+	EEventTypes,
+	TAccount,
+	TAvailableNetworks,
+} from '@synonymdev/react-native-ldk';
+import { backupAccount, getItem, importAccount, setItem } from '../ldk';
 import { EAccount } from './types';
 import { err, ok, Result } from './result';
 import { randomBytes } from 'react-native-randombytes';
@@ -10,6 +14,8 @@ import RNFS from 'react-native-fs';
 import * as bip32 from 'bip32';
 import * as bip39 from 'bip39';
 import { ENetworks } from '@synonymdev/react-native-ldk/dist/utils/types';
+import ldk from '@synonymdev/react-native-ldk/dist/ldk';
+import Clipboard from '@react-native-clipboard/clipboard';
 
 /**
  * Use Keychain to save LDK name & seed.
@@ -204,4 +210,79 @@ export const ldkNetwork = (network: TAvailableNetworks): ENetworks => {
 		case 'bitcoin':
 			return ENetworks.mainnet;
 	}
+};
+
+export const simulateStaleRestore = async (
+	onUpdate: (string) => void,
+): Promise<void> => {
+	const channels = await ldk.listChannels();
+	if (channels.isErr()) {
+		throw channels.error;
+	}
+	if (channels.value.filter((c) => c.is_usable).length === 0) {
+		throw new Error('No usable channels. Open a channel first.');
+	}
+
+	onUpdate('Backing up...');
+	const backupResponse = await backupAccount();
+	if (backupResponse.isErr()) {
+		throw backupResponse.error;
+	}
+
+	const timeoutSeconds = 30;
+	const invoice = await ldk.createPaymentRequest({
+		amountSats: 12,
+		description: 'crash test',
+		expiryDeltaSeconds: timeoutSeconds,
+	});
+	if (invoice.isErr()) {
+		throw invoice.error;
+	}
+
+	let paymentClaimed = false;
+	let paymentSubscription = ldk.onEvent(
+		EEventTypes.channel_manager_payment_claimed,
+		() => (paymentClaimed = true),
+	);
+
+	Clipboard.setString(invoice.value.to_str);
+
+	//Keep checking if we got the payment
+	for (let i = 0; i < timeoutSeconds; i++) {
+		onUpdate(
+			`Please pay invoice in clipboard to continue (${timeoutSeconds - i})...`,
+		);
+
+		if (paymentClaimed) {
+			onUpdate('Payment claimed! Testing stale restore...');
+			break;
+		}
+
+		await new Promise((resolve) => setTimeout(resolve, 1000));
+	}
+
+	paymentSubscription.remove();
+
+	if (!paymentClaimed) {
+		throw new Error('No payment claimed. Timeout out.');
+	}
+
+	onUpdate('Importing stale backup and force closing all channels...');
+
+	await new Promise((resolve) => setTimeout(resolve, 2500));
+
+	await ldk.stop();
+	const forceCloseAllChannels = true; //To test the crash restore set to false
+	const importResponse = await importAccount(
+		backupResponse.value,
+		forceCloseAllChannels,
+	);
+	if (importResponse.isErr()) {
+		throw importResponse.error;
+	}
+
+	await new Promise((resolve) => setTimeout(resolve, 2500));
+	onUpdate(
+		"If this didn't crash and you can see your claimable balance, you're good!",
+	);
 };

--- a/lib/android/src/main/java/com/reactnativeldk/LdkModule.kt
+++ b/lib/android/src/main/java/com/reactnativeldk/LdkModule.kt
@@ -610,6 +610,19 @@ class LdkModule(reactContext: ReactApplicationContext) : ReactContextBaseJavaMod
     }
 
     @ReactMethod
+    fun forceCloseAllChannels(broadcastLatestTx: Boolean, promise: Promise) {
+        channelManager ?: return handleReject(promise, LdkErrors.init_channel_manager)
+
+        if (broadcastLatestTx) {
+            channelManager!!.force_close_all_channels_broadcasting_latest_txn()
+        } else {
+            channelManager!!.force_close_all_channels_without_broadcasting_txn()
+        }
+
+        handleResolve(promise, LdkCallbackResponses.close_channel_success)
+    }
+
+    @ReactMethod
     fun spendOutputs(descriptorsSerialized: ReadableArray, outputs: ReadableArray, changeDestinationScript: String, feeRate: Double, promise: Promise) {
         keysManager ?: return handleReject(promise, LdkErrors.init_keys_manager)
 

--- a/lib/ios/Ldk.m
+++ b/lib/ios/Ldk.m
@@ -69,6 +69,9 @@ RCT_EXTERN_METHOD(closeChannel:(NSString *)channelId
                   force:(BOOL *)force
                   resolve:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject)
+RCT_EXTERN_METHOD(forceCloseAllChannels:(BOOL *)broadcastLatestTx
+                  resolve:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject)
 RCT_EXTERN_METHOD(spendOutputs:(NSArray *)descriptorsSerialized
                   outputs:(NSArray *)outputs
                   changeDestinationScript:(NSString *)changeDestinationScript

--- a/lib/ios/Ldk.swift
+++ b/lib/ios/Ldk.swift
@@ -654,6 +654,21 @@ class Ldk: NSObject {
     }
     
     @objc
+    func forceCloseAllChannels(_ broadcastLatestTx: Bool, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+        guard let channelManager = channelManager else {
+            return handleReject(reject, .init_channel_manager)
+        }
+        
+        if broadcastLatestTx {
+            channelManager.forceCloseAllChannelsBroadcastingLatestTxn()
+        } else {
+            channelManager.forceCloseAllChannelsWithoutBroadcastingTxn()
+        }
+        
+        return handleResolve(resolve, .close_channel_success)
+    }
+    
+    @objc
     func spendOutputs(_ descriptorsSerialized: NSArray, outputs: NSArray, changeDestinationScript: NSString, feeRate: NSInteger, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
         guard let keysManager = keysManager else {
             return handleReject(reject, .init_keys_manager)

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@synonymdev/react-native-ldk",
   "title": "React Native LDK",
-  "version": "0.0.98",
+  "version": "0.0.99",
   "description": "React Native wrapper for LDK",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/lib/src/ldk.ts
+++ b/lib/src/ldk.ts
@@ -437,6 +437,24 @@ class LDK {
 	}
 
 	/**
+	 * Force close all channels
+	 * @param broadcastLatestTx
+	 * @returns {Promise<Err<unknown> | Ok<Ok<string> | Err<string>>>}
+	 */
+	async forceCloseAllChannels(
+		broadcastLatestTx: boolean,
+	): Promise<Result<string>> {
+		try {
+			const res = await NativeLDK.forceCloseAllChannels(broadcastLatestTx);
+			this.writeDebugToLog('forceCloseAllChannels');
+			return ok(res);
+		} catch (e) {
+			this.writeErrorToLog('forceCloseAllChannels', e);
+			return err(e);
+		}
+	}
+
+	/**
 	 * Use LDK key manager to spend spendable outputs
 	 * https://docs.rs/lightning/latest/lightning/chain/keysinterface/struct.KeysManager.html#method.spend_spendable_outputs
 	 * @param descriptors

--- a/lib/src/lightning-manager.ts
+++ b/lib/src/lightning-manager.ts
@@ -245,6 +245,7 @@ class LightningManager {
 		broadcastTransaction,
 		network,
 		rapidGossipSyncUrl = 'https://rapidsync.lightningdevkit.org/snapshot/',
+		forceCloseOnStartup,
 		userConfig = defaultUserConfig,
 	}: TLdkStart): Promise<Result<string>> {
 		if (!account) {
@@ -425,6 +426,11 @@ class LightningManager {
 
 		// Set fee estimates
 		await this.setFees();
+
+		//Force close all channels on startup. Likely to recover funds after restoring from a stale backup.
+		if (forceCloseOnStartup && forceCloseOnStartup.forceClose) {
+			await ldk.forceCloseAllChannels(forceCloseOnStartup.broadcastLatestTx);
+		}
 
 		// Add cached peers
 		await this.addPeers();

--- a/lib/src/utils/types.ts
+++ b/lib/src/utils/types.ts
@@ -495,6 +495,11 @@ export type TAccount = {
 	seed: string;
 };
 
+type TForceCloseOnStartup = {
+	forceClose: boolean;
+	broadcastLatestTx: boolean;
+};
+
 export type TLdkStart = {
 	account: TAccount;
 	getBestBlock: TGetBestBlock;
@@ -506,6 +511,7 @@ export type TLdkStart = {
 	broadcastTransaction: TBroadcastTransaction;
 	network: ENetworks;
 	rapidGossipSyncUrl?: string;
+	forceCloseOnStartup?: TForceCloseOnStartup;
 	userConfig?: TUserConfig;
 };
 


### PR DESCRIPTION
Allows LDK to be started up with force closing all channels with or without broadcasting latest transactions.

Useful for recovering from an accidental stale backup restore. If a stale channel monitor is restored the counterparty force closes the channel automatically but the LDK node is stuck in a crash loop after adding peers as it won't continue to avoid losing funds. Force closing without broadcasting latest tx can resolve this but you are semi trusting your counterparty so this shouldn't be used unless absolutely necessary to recover user funds.

Example app test function `simulateStaleRestore()`  which does the following:

  - Creates a snapshot of current channel state
  - Creates an invoice
  - Waits for payment
  - Stops LDK
  - Imports stale account
  - Restarts with force closing all channels without broadcasting latest tx before adding peers
  - If it doesn't crash and it results in a pending claimable balance then it's working
  - To test the crash, change `forceCloseAllChannels` to `false` in `simulateStaleRestore()`