### PR TITLE
feat(lightning): Add signet params to networks object

### DIFF
--- a/example/utils/helpers.ts
+++ b/example/utils/helpers.ts
@@ -10,6 +10,7 @@ import RNFS from 'react-native-fs';
 import * as bip32 from 'bip32';
 import * as bip39 from 'bip39';
 import { ENetworks } from '@synonymdev/react-native-ldk/dist/utils/types';
+import networks from '@synonymdev/react-native-ldk/dist/utils/networks';
 
 /**
  * Use Keychain to save LDK name & seed.
@@ -119,13 +120,15 @@ export const getNetwork = (
 ): bitcoin.networks.Network => {
 	switch (network) {
 		case 'bitcoin':
-			return bitcoin.networks.bitcoin;
+			return networks.bitcoin;
 		case 'bitcoinTestnet':
-			return bitcoin.networks.testnet;
+			return networks.testnet;
 		case 'bitcoinRegtest':
-			return bitcoin.networks.regtest;
+			return networks.regtest;
+		case 'bitcoinSignet':
+			return networks.signet;
 		default:
-			return bitcoin.networks.regtest;
+			return networks.regtest;
 	}
 };
 

--- a/lib/src/lightning-manager.ts
+++ b/lib/src/lightning-manager.ts
@@ -61,7 +61,7 @@ import {
 	startParamCheck,
 } from './utils/helpers';
 import * as bitcoin from 'bitcoinjs-lib';
-import { networks } from 'bitcoinjs-lib';
+import networks from './utils/networks';
 import { EmitterSubscription } from 'react-native';
 
 //TODO startup steps
@@ -383,7 +383,7 @@ class LightningManager {
 		// Step 7: Read ChannelMonitors state from disk
 		// Handled in initChannelManager below
 
-		if (network !== 'mainnet') {
+		if (network !== ENetworks.mainnet) {
 			//RGS only currently working for mainnet
 			rapidGossipSyncUrl = '';
 		}

--- a/lib/src/mock.ts
+++ b/lib/src/mock.ts
@@ -1,3 +1,5 @@
+import { ENetworks } from './utils/types';
+
 export * from './utils/types';
 
 const noop = (): void => {};
@@ -50,7 +52,7 @@ export default {
 	backupSubscriptions: {},
 	backupSubscriptionsId: 1,
 	backupSubscriptionsDebounceTimer: 1,
-	network: 'mainnet',
+	network: ENetworks.mainnet,
 	baseStoragePath: '/ldk/',
 	logFilePath: '/ldk/wallet0bitcoinldkaccount/logs/1.log',
 };

--- a/lib/src/utils/helpers.ts
+++ b/lib/src/utils/helpers.ts
@@ -1,8 +1,7 @@
 import { ENetworks, TLdkStart } from './types';
 import { err, ok, Result } from './result';
 import * as bitcoin from 'bitcoinjs-lib';
-import { networks } from 'bitcoinjs-lib';
-
+import networks from './networks';
 /**
  * This method runs a check on each parameter passed to the start method
  * to ensure that they are providing the expected data.

--- a/lib/src/utils/networks.ts
+++ b/lib/src/utils/networks.ts
@@ -1,0 +1,23 @@
+import * as bitcoin from 'bitcoinjs-lib';
+import { ENetworks } from './types';
+
+const networks: {
+	[ENetworks.mainnet]: bitcoin.networks.Network;
+	[ENetworks.testnet]: bitcoin.networks.Network;
+	[ENetworks.regtest]: bitcoin.networks.Network;
+	[ENetworks.signet]: bitcoin.networks.Network;
+} = {
+	...bitcoin.networks,
+	signet: {
+		messagePrefix: '\x18Bitcoin Signed Message:\n',
+		bech32: 'ts',
+		bip32: {
+			public: 0x043587cf,
+			private: 0x04358394,
+		},
+		pubKeyHash: 0x7d,
+		scriptHash: 0x6e,
+		wif: 0xef,
+	},
+};
+export default networks;

--- a/lib/src/utils/types.ts
+++ b/lib/src/utils/types.ts
@@ -2,7 +2,7 @@ export enum ENetworks {
 	signet = 'signet',
 	regtest = 'regtest',
 	testnet = 'testnet',
-	mainnet = 'mainnet',
+	mainnet = 'bitcoin',
 }
 
 export type TAvailableNetworks =


### PR DESCRIPTION
This PR:
- Creates `networks.ts` file and adds `signet` key with new params.
- Updates references to the `networks` file accordingly.
- Updated `ENetworks.mainnet` value to `bitcoin` to match bitcoinjs-lib's `networks` object key.