### PR TITLE
fix: native rename 'mainnet' to 'bitcoin'

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -302,7 +302,7 @@ PODS:
   - React-jsinspector (0.70.6)
   - React-logger (0.70.6):
     - glog
-  - react-native-ldk (0.0.99):
+  - react-native-ldk (0.0.102):
     - React
   - react-native-randombytes (3.6.1):
     - React-Core
@@ -593,7 +593,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: b4a65947391c658450151275aa406f2b8263178f
   React-jsinspector: 60769e5a0a6d4b32294a2456077f59d0266f9a8b
   React-logger: 1623c216abaa88974afce404dc8f479406bbc3a0
-  react-native-ldk: 175104646d32a4f52d82299c6981ad4bf91ad603
+  react-native-ldk: 68471c25f1e36ae5b2f59f3002016a815f781480
   react-native-randombytes: 421f1c7d48c0af8dbcd471b0324393ebf8fe7846
   react-native-tcp-socket: c1b7297619616b4c9caae6889bcb0aba78086989
   React-perflogger: 8c79399b0500a30ee8152d0f9f11beae7fc36595

--- a/lib/android/src/main/java/com/reactnativeldk/Helpers.kt
+++ b/lib/android/src/main/java/com/reactnativeldk/Helpers.kt
@@ -377,7 +377,7 @@ fun UserConfig.mergeWithMap(map: ReadableMap): UserConfig {
 /// Helper for returning real network and currency as a tuple from a string
 fun getNetwork(chain: String): Pair<Network, Currency> {
     return when (chain) {
-        "mainnet" -> Pair(Network.LDKNetwork_Bitcoin, Currency.LDKCurrency_Bitcoin)
+        "bitcoin" -> Pair(Network.LDKNetwork_Bitcoin, Currency.LDKCurrency_Bitcoin)
         "testnet" -> Pair(Network.LDKNetwork_Testnet, Currency.LDKCurrency_BitcoinTestnet)
         "regtest" -> Pair(Network.LDKNetwork_Regtest, Currency.LDKCurrency_Regtest)
         "signet" -> Pair(Network.LDKNetwork_Signet, Currency.LDKCurrency_Signet)

--- a/lib/ios/Helpers.swift
+++ b/lib/ios/Helpers.swift
@@ -421,7 +421,7 @@ func handlePaymentSendFailure(_ reject: RCTPromiseRejectBlock, error: Bindings.P
 /// - Returns: network and currency tuple
 func getNetwork(_ network: String) -> (Network, Currency)? {
     switch network {
-    case "mainnet":
+    case "bitcoin":
         return (Network.Bitcoin, Currency.Bitcoin)
     case "testnet":
         return (Network.Testnet, Currency.BitcoinTestnet)

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@synonymdev/react-native-ldk",
   "title": "React Native LDK",
-  "version": "0.0.99",
+  "version": "0.0.102",
   "description": "React Native wrapper for LDK",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
Native code was not matching the JS the network name