### PR TITLE
fix: android perform rgs download and update on background thread

### DIFF
--- a/lib/android/src/main/java/com/reactnativeldk/classes/LdkPersister.kt
+++ b/lib/android/src/main/java/com/reactnativeldk/classes/LdkPersister.kt
@@ -36,7 +36,6 @@ class LdkPersister {
 
             return ChannelMonitorUpdateStatus.LDKChannelMonitorUpdateStatus_Completed
         } catch (e: Exception) {
-            LdkEventEmitter.send(EventTypes.emergency_force_close_channel, body)
             return ChannelMonitorUpdateStatus.LDKChannelMonitorUpdateStatus_UnrecoverableError
         }
     }


### PR DESCRIPTION
- Downloads RGS file and updates on background thread then performs callback on main thread
- Removes auto channel close on failed remote persist. It was removed from iOS a while back but stayed in Android.