### PR TITLE
Remote persist retries

### DIFF
--- a/lib/android/src/main/java/com/reactnativeldk/classes/BackupClient.kt
+++ b/lib/android/src/main/java/com/reactnativeldk/classes/BackupClient.kt
@@ -214,6 +214,10 @@ class BackupClient {
                     EventTypes.native_log,
                     "Remote persist failed for ${label.string} with response code ${urlConnection.responseCode}"
                 )
+                LdkEventEmitter.send(
+                    EventTypes.backup_sync_persist_error,
+                    "Response: ${urlConnection.responseMessage}"
+                )
 
                 throw InvalidServerResponse(urlConnection.responseCode)
             }

--- a/lib/android/src/main/java/com/reactnativeldk/classes/LdkChannelManagerPersister.kt
+++ b/lib/android/src/main/java/com/reactnativeldk/classes/LdkChannelManagerPersister.kt
@@ -173,9 +173,8 @@ class LdkChannelManagerPersister: ChannelManagerConstructor.EventHandler {
 
     override fun persist_manager(channel_manager_bytes: ByteArray?) {
         if (channel_manager_bytes != null && LdkModule.accountStoragePath != "") {
+            BackupClient.persist(BackupClient.Label.CHANNEL_MANAGER(), channel_manager_bytes, retry = 100)
             File(LdkModule.accountStoragePath + "/" + LdkFileNames.channel_manager.fileName).writeBytes(channel_manager_bytes)
-
-            BackupClient.persist(BackupClient.Label.CHANNEL_MANAGER(), channel_manager_bytes)
 
             LdkEventEmitter.send(EventTypes.native_log, "Persisted channel manager to disk")
             LdkEventEmitter.send(EventTypes.backup, "")

--- a/lib/android/src/main/java/com/reactnativeldk/classes/LdkPersister.kt
+++ b/lib/android/src/main/java/com/reactnativeldk/classes/LdkPersister.kt
@@ -24,8 +24,8 @@ class LdkPersister {
 
             val isNew = !file.exists()
 
+            BackupClient.persist(BackupClient.Label.CHANNEL_MONITOR(channelId=channelId), data.write(), retry = 100)
             file.writeBytes(data.write())
-            BackupClient.persist(BackupClient.Label.CHANNEL_MONITOR(channelId=channelId), data.write())
 
             LdkEventEmitter.send(EventTypes.native_log, "Persisted channel (${id.to_channel_id().hexEncodedString()}) to disk")
             LdkEventEmitter.send(EventTypes.backup, "")

--- a/lib/ios/Classes/LdkChannelManagerPersister.swift
+++ b/lib/ios/Classes/LdkChannelManagerPersister.swift
@@ -267,10 +267,10 @@ class LdkChannelManagerPersister: Persister, ExtendedChannelManagerPersister {
         }
         
         do {
+            try BackupClient.persist(.channelManager, channelManager.write(), retry: 10)
+
             try Data(channelManager.write()).write(to: managerStorage)
-            LdkEventEmitter.shared.send(withEvent: .native_log, body: "Persisted channel manager to disk")
-            
-            try BackupClient.persist(.channelManager, channelManager.write())
+            LdkEventEmitter.shared.send(withEvent: .native_log, body: "Persisted channel manager to disk")            
                         
             LdkEventEmitter.shared.send(withEvent: .backup, body: "")
             

--- a/lib/ios/Classes/LdkChannelManagerPersister.swift
+++ b/lib/ios/Classes/LdkChannelManagerPersister.swift
@@ -267,7 +267,7 @@ class LdkChannelManagerPersister: Persister, ExtendedChannelManagerPersister {
         }
         
         do {
-            try BackupClient.persist(.channelManager, channelManager.write(), retry: 10)
+            try BackupClient.persist(.channelManager, channelManager.write(), retry: 100)
 
             try Data(channelManager.write()).write(to: managerStorage)
             LdkEventEmitter.shared.send(withEvent: .native_log, body: "Persisted channel manager to disk")            

--- a/lib/ios/Classes/LdkPersist.swift
+++ b/lib/ios/Classes/LdkPersist.swift
@@ -23,12 +23,11 @@ class LdkPersister: Persist {
             
             let isNew = !FileManager().fileExists(atPath: channelStoragePath.path)
                         
+            try BackupClient.persist(.channelMonitor(id: channelId), data.write(), retry: 10)
             try Data(data.write()).write(to: channelStoragePath)
-            try BackupClient.persist(.channelMonitor(id: channelId), data.write())
             
             LdkEventEmitter.shared.send(withEvent: .native_log, body: "Persisted channel (\(channelId)) to disk")
             LdkEventEmitter.shared.send(withEvent: .backup, body: "")
-            
             
             if isNew {
                 LdkEventEmitter.shared.send(

--- a/lib/ios/Classes/LdkPersist.swift
+++ b/lib/ios/Classes/LdkPersist.swift
@@ -23,7 +23,7 @@ class LdkPersister: Persist {
             
             let isNew = !FileManager().fileExists(atPath: channelStoragePath.path)
                         
-            try BackupClient.persist(.channelMonitor(id: channelId), data.write(), retry: 10)
+            try BackupClient.persist(.channelMonitor(id: channelId), data.write(), retry: 100)
             try Data(data.write()).write(to: channelStoragePath)
             
             LdkEventEmitter.shared.send(withEvent: .native_log, body: "Persisted channel (\(channelId)) to disk")

--- a/lib/src/ldk.ts
+++ b/lib/src/ldk.ts
@@ -81,22 +81,6 @@ class LDK {
 	}
 
 	/**
-	 * Connected and disconnected blocks must be provided
-	 * https://docs.rs/lightning/latest/lightning/chain/chainmonitor/struct.ChainMonitor.html
-	 * @returns {Promise<Err<unknown> | Ok<Ok<string> | Err<string>>>}
-	 */
-	async initChainMonitor(): Promise<Result<string>> {
-		try {
-			const res = await NativeLDK.initChainMonitor();
-			this.writeDebugToLog('initChainMonitor');
-			return ok(res);
-		} catch (e) {
-			this.writeErrorToLog('initChainMonitor', e);
-			return err(e);
-		}
-	}
-
-	/**
 	 * Private key for node. Used to derive node public key. 32-byte entropy.
 	 * https://docs.rs/lightning/latest/lightning/chain/keysinterface/struct.KeysManager.html
 	 * @param seed

--- a/lib/src/ldk.ts
+++ b/lib/src/ldk.ts
@@ -1129,7 +1129,9 @@ class LDK {
 			this.writeDebugToLog('readFromFile', fileName);
 			return ok({ ...res, timestamp: Math.round(res.timestamp) });
 		} catch (e) {
-			this.writeErrorToLog('readFromFile', e);
+			if (JSON.stringify(e).indexOf('Could not locate file') < 0) {
+				this.writeErrorToLog('readFromFile', e);
+			}
 			return err(e);
 		}
 	}

--- a/lib/src/lightning-manager.ts
+++ b/lib/src/lightning-manager.ts
@@ -387,11 +387,7 @@ class LightningManager {
 		// Lazy loaded in native code
 		// https://docs.rs/lightning/latest/lightning/chain/chainmonitor/trait.Persist.html
 
-		// Step 5: Initialize the ChainMonitor
-		const chainMonitorRes = await ldk.initChainMonitor();
-		if (chainMonitorRes.isErr()) {
-			return chainMonitorRes;
-		}
+		// Step 5: Initialize the ChainMonitor (happens when we init the ChannelManager
 
 		// Step 6: Initialize the KeysManager
 		const keysManager = await ldk.initKeysManager(this.account.seed);


### PR DESCRIPTION
- Removes initChainMonitor() call. Chain monitor is just now initialised when constructing the channel manager where it is needed. Might improve a restart bug on iOS.
- Android and iOS auto retry on remote persist fail. This is a temporary solution to avoid crashes and random force closes. 