### PR TITLE
fix: int overflow for short channel IDs

### DIFF
--- a/lib/android/src/main/java/com/reactnativeldk/Helpers.kt
+++ b/lib/android/src/main/java/com/reactnativeldk/Helpers.kt
@@ -123,12 +123,21 @@ val ChannelDetails.asJson: WritableMap
         result.putHexString("channel_type", _channel_type?.write())
         result.putString("user_channel_id", _user_channel_id.leBytes.hexEncodedString())
         result.putInt("confirmations_required", (_confirmations_required as Option_u32Z.Some).some)
-        (_short_channel_id as? Option_u64Z.Some)?.some?.toInt()
-            ?.let { result.putString("short_channel_id", it.toString()) } //Optional number
-        (_inbound_scid_alias as? Option_u64Z.Some)?.some?.toInt()
-            ?.let { result.putInt("inbound_scid_alias", it) }
-        (_inbound_scid_alias as? Option_u64Z.Some)?.some?.toInt()
-            ?.let { result.putInt("inbound_payment_scid", it) }
+        if (_short_channel_id is Option_u64Z.Some) {
+            result.putString("short_channel_id", (_short_channel_id as Option_u64Z.Some).some.toULong().toString())
+        } else {
+            result.putString("short_channel_id", "")
+        }
+        if (_inbound_scid_alias is Option_u64Z.Some) {
+            result.putString("inbound_scid_alias", (_inbound_scid_alias as Option_u64Z.Some).some.toULong().toString())
+        } else {
+            result.putString("inbound_scid_alias", "")
+        }
+        if (_inbound_payment_scid is Option_u64Z.Some) {
+            result.putString("inbound_payment_scid", (_inbound_payment_scid as Option_u64Z.Some).some.toULong().toString())
+        } else {
+            result.putString("inbound_payment_scid", "")
+        }
         result.putInt("inbound_capacity_sat", (_inbound_capacity_msat / 1000).toInt())
         result.putInt("outbound_capacity_sat", (_outbound_capacity_msat / 1000).toInt())
         result.putInt("channel_value_satoshis", _channel_value_satoshis.toInt())

--- a/lib/ios/Helpers.swift
+++ b/lib/ios/Helpers.swift
@@ -112,7 +112,6 @@ extension RouteHintHop {
 //Our own channels
 extension ChannelDetails {
     var asJson: [String: Any] {
-        let shortChannelId = getShortChannelId()
         return [
             "channel_id": Data(getChannelId() ?? []).hexEncodedString(),
             "is_public": getIsPublic(),
@@ -123,11 +122,11 @@ extension ChannelDetails {
             "counterparty_node_id": Data(getCounterparty().getNodeId()).hexEncodedString(),
             "funding_txid": Data(getFundingTxo()?.getTxid()?.reversed() ?? []).hexEncodedString(),
             "channel_type": Data(getChannelType()?.write() ?? []).hexEncodedString(),
-            "user_channel_id": Data(getUserChannelId()).hexEncodedString(), //Sting
+            "user_channel_id": Data(getUserChannelId()).hexEncodedString(), //String
             "confirmations_required": getConfirmationsRequired() as Any, // Optional number
-            "short_channel_id": shortChannelId != nil ? String(shortChannelId!) : "",
-            "inbound_scid_alias": getInboundScidAlias() as Any, //Optional number
-            "inbound_payment_scid": getInboundPaymentScid() as Any, //Optional number,
+            "short_channel_id": getShortChannelId() != nil ? String(getShortChannelId()!) : "", //String
+            "inbound_scid_alias": getInboundScidAlias() != nil ? String(getInboundScidAlias()!) : "", //String
+            "inbound_payment_scid": getInboundPaymentScid() != nil ? String(getInboundPaymentScid()!) : "", //String
             "inbound_capacity_sat": getInboundCapacityMsat() / 1000,
             "outbound_capacity_sat": getOutboundCapacityMsat() / 1000,
             "channel_value_satoshis": getChannelValueSatoshis(),

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@synonymdev/react-native-ldk",
   "title": "React Native LDK",
-  "version": "0.0.114",
+  "version": "0.0.118",
   "description": "React Native wrapper for LDK",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/lib/src/utils/types.ts
+++ b/lib/src/utils/types.ts
@@ -151,8 +151,8 @@ export type TChannel = {
 	user_channel_id: string;
 	confirmations_required?: number;
 	short_channel_id: string;
-	inbound_scid_alias?: number;
-	inbound_payment_scid?: number;
+	inbound_scid_alias: string;
+	inbound_payment_scid: string;
 	inbound_capacity_sat: number;
 	outbound_capacity_sat: number;
 	channel_value_satoshis: number;


### PR DESCRIPTION
short_channel_id, inbound_scid_alias and inbound_payment_scid are all UInt64 types which overflow in JS numbers so converted number types to strings