### PR TITLE
feat: pre-populated scorer download

### DIFF
--- a/example/ldk/index.ts
+++ b/example/ldk/index.ts
@@ -11,8 +11,6 @@ import {
 import lm, {
 	DefaultTransactionDataShape,
 	defaultUserConfig,
-	TAccount,
-	TAccountBackup,
 	THeader,
 	TTransactionData,
 	TTransactionPosition,
@@ -28,9 +26,7 @@ import {
 	getAddress,
 	getNetwork,
 	ldkNetwork,
-	setAccount,
 } from '../utils/helpers';
-import { EAccount } from '../utils/types';
 import * as bitcoin from 'bitcoinjs-lib';
 
 /**
@@ -323,43 +319,4 @@ export const broadcastTransaction = async (rawTx: string): Promise<string> => {
 		console.log(e);
 		return '';
 	}
-};
-
-/**
- * Used to backup a given account.
- * @param {TAccount} [account]
- * @returns {Promise<Result<string>>}
- */
-export const backupAccount = async (
-	account?: TAccount,
-): Promise<Result<TAccountBackup>> => {
-	if (!account) {
-		account = await getAccount();
-	}
-	return await lm.backupAccount({
-		account,
-	});
-};
-
-/**
- * Used to import an account using the backup JSON string or TAccountBackup object.
- * @param {string | TAccountBackup} backup
- * @returns {Promise<Result<TAccount>>}
- */
-export const importAccount = async (
-	backup: string | TAccountBackup,
-	forceCloseAllChannels = false,
-): Promise<Result<TAccount>> => {
-	const importResponse = await lm.importAccount({
-		backup,
-		overwrite: true,
-	});
-	if (importResponse.isErr()) {
-		return err(importResponse.error.message);
-	}
-	await setAccount(importResponse.value);
-	await setItem(EAccount.currentAccountKey, importResponse.value.name);
-	await setupLdk(forceCloseAllChannels);
-	await syncLdk();
-	return ok(importResponse.value);
 };

--- a/example/tests/lnd.ts
+++ b/example/tests/lnd.ts
@@ -559,7 +559,15 @@ describe('LND', function () {
 		// - force close channel from LDK
 		// - check everything is ok
 
-		let fees = { highPriority: 3, normal: 2, background: 1, mempoolMinimum: 1 };
+		let fees = {
+			nonAnchorChannelFee: 5,
+			anchorChannelFee: 5,
+			maxAllowedNonAnchorChannelRemoteFee: 5,
+			channelCloseMinimum: 5,
+			minAllowedAnchorChannelRemoteFee: 5,
+			minAllowedNonAnchorChannelRemoteFee: 5,
+			onChainSweep: 5,
+		};
 
 		const lmStart = await lm.start({
 			...profile.getStartParams(),
@@ -656,7 +664,15 @@ describe('LND', function () {
 		);
 
 		// set height fees and restart LDK so it catches up
-		fees = { highPriority: 30, normal: 20, background: 10, mempoolMinimum: 1 };
+		fees = {
+			nonAnchorChannelFee: 30,
+			anchorChannelFee: 30,
+			maxAllowedNonAnchorChannelRemoteFee: 30,
+			channelCloseMinimum: 5,
+			minAllowedAnchorChannelRemoteFee: 5,
+			minAllowedNonAnchorChannelRemoteFee: 5,
+			onChainSweep: 30,
+		};
 		const syncRes0 = await lm.syncLdk();
 		await lm.setFees();
 		if (syncRes0.isErr()) {

--- a/example/tests/unit.ts
+++ b/example/tests/unit.ts
@@ -59,10 +59,13 @@ describe('Unit', function () {
 			getScriptPubKeyHistory: async () => [],
 			getFees: () => {
 				return Promise.resolve({
-					highPriority: 10,
-					normal: 5,
-					background: 2,
-					mempoolMinimum: 1,
+					nonAnchorChannelFee: 5,
+					anchorChannelFee: 5,
+					maxAllowedNonAnchorChannelRemoteFee: 5,
+					channelCloseMinimum: 5,
+					minAllowedAnchorChannelRemoteFee: 5,
+					minAllowedNonAnchorChannelRemoteFee: 5,
+					onChainSweep: 5,
 				});
 			},
 			getTransactionData: async () => ({

--- a/example/utils/helpers.ts
+++ b/example/utils/helpers.ts
@@ -1,10 +1,6 @@
 import Keychain from 'react-native-keychain';
-import {
-	EEventTypes,
-	TAccount,
-	TAvailableNetworks,
-} from '@synonymdev/react-native-ldk';
-import { backupAccount, getItem, importAccount, setItem } from '../ldk';
+import { TAccount, TAvailableNetworks } from '@synonymdev/react-native-ldk';
+import { getItem, setItem } from '../ldk';
 import { EAccount } from './types';
 import { err, ok, Result } from './result';
 import { randomBytes } from 'react-native-randombytes';
@@ -15,8 +11,6 @@ import * as bip32 from 'bip32';
 import * as bip39 from 'bip39';
 import { ENetworks } from '@synonymdev/react-native-ldk/dist/utils/types';
 import networks from '@synonymdev/react-native-ldk/dist/utils/networks';
-import ldk from '@synonymdev/react-native-ldk/dist/ldk';
-import Clipboard from '@react-native-clipboard/clipboard';
 
 /**
  * Use Keychain to save LDK name & seed.
@@ -215,79 +209,4 @@ export const ldkNetwork = (network: TAvailableNetworks): ENetworks => {
 		case 'bitcoinSignet':
 			return ENetworks.signet;
 	}
-};
-
-export const simulateStaleRestore = async (
-	onUpdate: (string) => void,
-): Promise<void> => {
-	const channels = await ldk.listChannels();
-	if (channels.isErr()) {
-		throw channels.error;
-	}
-	if (channels.value.filter((c) => c.is_usable).length === 0) {
-		throw new Error('No usable channels. Open a channel first.');
-	}
-
-	onUpdate('Backing up...');
-	const backupResponse = await backupAccount();
-	if (backupResponse.isErr()) {
-		throw backupResponse.error;
-	}
-
-	const timeoutSeconds = 30;
-	const invoice = await ldk.createPaymentRequest({
-		amountSats: 12,
-		description: 'crash test',
-		expiryDeltaSeconds: timeoutSeconds,
-	});
-	if (invoice.isErr()) {
-		throw invoice.error;
-	}
-
-	let paymentClaimed = false;
-	let paymentSubscription = ldk.onEvent(
-		EEventTypes.channel_manager_payment_claimed,
-		() => (paymentClaimed = true),
-	);
-
-	Clipboard.setString(invoice.value.to_str);
-
-	//Keep checking if we got the payment
-	for (let i = 0; i < timeoutSeconds; i++) {
-		onUpdate(
-			`Please pay invoice in clipboard to continue (${timeoutSeconds - i})...`,
-		);
-
-		if (paymentClaimed) {
-			onUpdate('Payment claimed! Testing stale restore...');
-			break;
-		}
-
-		await new Promise((resolve) => setTimeout(resolve, 1000));
-	}
-
-	paymentSubscription.remove();
-
-	if (!paymentClaimed) {
-		throw new Error('No payment claimed. Timeout out.');
-	}
-
-	onUpdate('Importing stale backup and force closing all channels...');
-
-	await new Promise((resolve) => setTimeout(resolve, 2500));
-
-	await ldk.stop();
-	const forceCloseAllChannels = true; //To test the crash restore set to false
-	const importResponse = await importAccount(
-		backupResponse.value,
-		forceCloseAllChannels,
-	);
-	if (importResponse.isErr()) {
-		throw importResponse.error;
-	}
-
-	await new Promise((resolve) => setTimeout(resolve, 2500));
-	onUpdate(
-		"If this didn't crash and you can see your claimable balance, you're good!",
-	);
 };

--- a/lib/ios/Ldk.m
+++ b/lib/ios/Ldk.m
@@ -13,7 +13,6 @@ RCT_EXTERN_METHOD(setLogFilePath:(NSString *)path
 RCT_EXTERN_METHOD(writeToLogFile:(NSString *)line
                   resolve:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject)
-
 RCT_EXTERN_METHOD(initChainMonitor:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject)
 RCT_EXTERN_METHOD(initKeysManager:(NSString *)seed
@@ -22,8 +21,13 @@ RCT_EXTERN_METHOD(initKeysManager:(NSString *)seed
 RCT_EXTERN_METHOD(initUserConfig:(NSDictionary *)userConfig
                   resolve:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject)
+RCT_EXTERN_METHOD(downloadScorer:(NSString *)scorerSyncUrl
+                  skipHoursThreshold:(NSInteger *)skipHoursThreshold
+                  resolve:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject)
 RCT_EXTERN_METHOD(initNetworkGraph:(NSString *)network
                   rapidGossipSyncUrl:(NSString *)rapidGossipSyncUrl
+                  skipHoursThreshold:(NSInteger *)skipHoursThreshold
                   resolve:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject)
 RCT_EXTERN_METHOD(initChannelManager:(NSString *)network

--- a/lib/ios/Ldk.swift
+++ b/lib/ios/Ldk.swift
@@ -482,12 +482,7 @@ class Ldk: NSObject {
         currentBlockchainTipHash = blockHash
         currentBlockchainHeight = blockHeight
         addForegroundObserver()
-        
-        print("Scorer:")
-//        Task {
-//            probabilisticScorer.debugLogLiquidityStats()
-//        }
-                
+           
         return handleResolve(resolve, .channel_manager_init_success)
     }
     

--- a/lib/ios/Ldk.swift
+++ b/lib/ios/Ldk.swift
@@ -436,9 +436,7 @@ class Ldk: NSObject {
         )
         
         do {
-            //Only restore a node if we have existing channel monitors to restore. Else we lose our UserConfig settings when restoring.
-            //TOOD remove this check in 114 which should allow passing in userConfig
-            if let channelManagerSerialized = storedChannelManager, channelMonitorsSerialized.count > 0 {
+            if let channelManagerSerialized = storedChannelManager {
                 //Restoring node
                 LdkEventEmitter.shared.send(withEvent: .native_log, body: "Restoring node from disk")
                 

--- a/lib/src/lightning-manager.ts
+++ b/lib/src/lightning-manager.ts
@@ -148,6 +148,8 @@ class LightningManager {
 	private pendingStartPromises: Array<(result: Result<string>) => void> = [];
 	private previousAccountName: string = '';
 
+	private backupsServerSetup = false;
+
 	constructor() {
 		// Step 0: Subscribe to all events
 		ldk.onEvent(EEventTypes.native_log, (line) => {
@@ -447,6 +449,7 @@ class LightningManager {
 					details: backupServerDetails,
 				}),
 			);
+			this.backupsServerSetup = true;
 		}
 
 		// Check for any errors before starting channel manager.
@@ -984,7 +987,7 @@ class LightningManager {
 		overwrite?: boolean;
 	}): Promise<Result<TAccount>> => {
 		console.warn(
-			'This method is deprecated and should only be used to import accounts that were backed up with a previous async method.',
+			'importAccount() is deprecated and should only be used to import accounts that were backed up with a previous async method.',
 		);
 		if (!this.baseStoragePath) {
 			return err(
@@ -1148,6 +1151,9 @@ class LightningManager {
 		account: TAccount;
 		includeTransactionHistory?: boolean;
 	}): Promise<Result<TAccountBackup>> => {
+		console.warn(
+			'backupAccount() is deprecated and will be removed in future versions. Use remote backup server instead.',
+		);
 		if (!this.baseStoragePath) {
 			return err(
 				'baseStoragePath required for wallet persistence. Call setBaseStoragePath(path) first.',
@@ -1350,6 +1356,9 @@ class LightningManager {
 	subscribeToBackups(
 		callback: (backup: Result<TAccountBackup>) => void,
 	): string {
+		console.warn(
+			'subscribeToBackups() is deprecated, use backup server instead.',
+		);
 		this.backupSubscriptionsId++;
 		const id = `${this.backupSubscriptionsId}`;
 		this.backupSubscriptions[id] = callback;
@@ -1361,6 +1370,9 @@ class LightningManager {
 	 * @param id
 	 */
 	unsubscribeFromBackups(id: string): void {
+		console.warn(
+			'unsubscribeFromBackups() is deprecated, use backup server instead.',
+		);
 		if (this.backupSubscriptions[id]) {
 			delete this.backupSubscriptions[id];
 		}
@@ -1372,6 +1384,9 @@ class LightningManager {
 	 * @returns {Promise<void>}
 	 */
 	private async onLdkBackupEvent(): Promise<void> {
+		if (this.backupsServerSetup) {
+			return;
+		}
 		if (this.backupSubscriptionsDebounceTimer) {
 			clearTimeout(this.backupSubscriptionsDebounceTimer);
 		}

--- a/lib/src/lightning-manager.ts
+++ b/lib/src/lightning-manager.ts
@@ -349,7 +349,12 @@ class LightningManager {
 				return this.handleStartError(paramCheckResponse);
 			}
 		} else {
-			console.warn('Skipping start param check. Switch back on for debugging.');
+			ldk
+				.writeToLogFile(
+					'info',
+					'Skipping start param check. Set skipParamCheck=false for debugging.',
+				)
+				.catch(console.error);
 		}
 
 		this.getBestBlock = getBestBlock;

--- a/lib/src/lightning-manager.ts
+++ b/lib/src/lightning-manager.ts
@@ -473,17 +473,6 @@ class LightningManager {
 			return this.handleStartError(channelManagerRes);
 		}
 
-		// Attempt to abandon any stored payment ids.
-		const paymentIds = await this.getLdkPaymentIds();
-		if (paymentIds.length) {
-			await Promise.all(
-				paymentIds.map(async (paymentId) => {
-					await ldk.abandonPayment(paymentId);
-					await this.removeLdkPaymentId(paymentId);
-				}),
-			);
-		}
-
 		//Force close all channels on startup. Likely to recover funds after restoring from a stale backup.
 		if (forceCloseOnStartup && forceCloseOnStartup.forceClose) {
 			await ldk.forceCloseAllChannels(forceCloseOnStartup.broadcastLatestTx);

--- a/lib/src/utils/types.ts
+++ b/lib/src/utils/types.ts
@@ -310,9 +310,15 @@ export type TInitChannelManagerReq = {
 	};
 };
 
+export type TDownloadScorer = {
+	scorerDownloadUrl: string;
+	skipHoursThreshold?: number;
+};
+
 export type TInitNetworkGraphReq = {
 	network: ENetworks;
 	rapidGossipSyncUrl?: string;
+	skipHoursThreshold?: number;
 };
 
 export type TChannelHandshakeConfig = {
@@ -553,6 +559,7 @@ export type TLdkStart = {
 	broadcastTransaction: TBroadcastTransaction;
 	network: ENetworks;
 	rapidGossipSyncUrl?: string;
+	scorerDownloadUrl?: string;
 	forceCloseOnStartup?: TForceCloseOnStartup;
 	userConfig?: TUserConfig;
 	trustedZeroConfPeers?: string[];

--- a/lib/src/utils/types.ts
+++ b/lib/src/utils/types.ts
@@ -564,6 +564,7 @@ export type TLdkStart = {
 	userConfig?: TUserConfig;
 	trustedZeroConfPeers?: string[];
 	backupServerDetails?: TBackupServerDetails;
+	skipParamCheck?: boolean;
 };
 
 export type TGetAddress = () => Promise<string>;


### PR DESCRIPTION
- Android and iOS download a pre-populated scorer from RGS server to improve payment reliability.
- Removed old backup function calls from example app.
- Added deprecated warnings to old backup calls, will remove completely in a future PR to simplify the code.
- Startup speed improvements:
  - Grouped startup functions that are not required to be run in any order to run async.
  - Skip startup param check `skipParamCheck: true` in lm.start(). Can be left on default false for debugging but should be used to avoid additional network calls on each startup once in prod. 
  - addPeers and sync methods called without await at the end of startup.