### PR TITLE
fix: increasing base_penalty_msat

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -302,7 +302,7 @@ PODS:
   - React-jsinspector (0.70.6)
   - React-logger (0.70.6):
     - glog
-  - react-native-ldk (0.0.120):
+  - react-native-ldk (0.0.122):
     - React
   - react-native-randombytes (3.6.1):
     - React-Core
@@ -593,7 +593,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: b4a65947391c658450151275aa406f2b8263178f
   React-jsinspector: 60769e5a0a6d4b32294a2456077f59d0266f9a8b
   React-logger: 1623c216abaa88974afce404dc8f479406bbc3a0
-  react-native-ldk: fc83520c891e58888c8f975a02ed394a4c4e1c36
+  react-native-ldk: 3fd5d959c60676bbb5f414a4c5e8a2cd3a4fb227
   react-native-randombytes: 421f1c7d48c0af8dbcd471b0324393ebf8fe7846
   react-native-tcp-socket: c1b7297619616b4c9caae6889bcb0aba78086989
   React-perflogger: 8c79399b0500a30ee8152d0f9f11beae7fc36595

--- a/lib/android/src/main/java/com/reactnativeldk/LdkModule.kt
+++ b/lib/android/src/main/java/com/reactnativeldk/LdkModule.kt
@@ -409,6 +409,9 @@ class LdkModule(reactContext: ReactApplicationContext) : ReactContextBaseJavaMod
 
         val scoringParams = ProbabilisticScoringDecayParameters.with_default()
         val scoringFeeParams = ProbabilisticScoringFeeParameters.with_default()
+        scoringFeeParams._base_penalty_msat = 500*1000
+
+        LdkEventEmitter.send(EventTypes.native_log, "Overriding base_penalty_msat: ${scoringFeeParams._base_penalty_msat}")
 
         chainMonitor = ChainMonitor.of(
             Option_FilterZ.some(filter.filter),

--- a/lib/ios/Ldk.swift
+++ b/lib/ios/Ldk.swift
@@ -421,6 +421,11 @@ class Ldk: NSObject {
 
         //        print("\(String(cString: strerror(22)))")
         
+        let scoreParams = ProbabilisticScoringFeeParameters.initWithDefault()
+        scoreParams.setBasePenaltyMsat(val: 500*1000)
+        
+        LdkEventEmitter.shared.send(withEvent: .native_log, body: "Overriding basePenaltyMsat: \(scoreParams.getBasePenaltyMsat())")
+        
         let params = ChannelManagerConstructionParameters(
             config: userConfig,
             entropySource: keysManager.asEntropySource(),
@@ -431,7 +436,8 @@ class Ldk: NSObject {
             txBroadcaster: broadcaster,
             logger: logger,
             enableP2PGossip: enableP2PGossip,
-            scorer: scorer
+            scorer: scorer,
+            scoreParams: scoreParams
             //TODO set payerRetries
         )
         
@@ -899,7 +905,7 @@ class Ldk: NSObject {
             amtMsat: amountSats == 0 ? nil : UInt64(amountSats) * 1000,
             description: String(description).withoutEmojis, //TODO remove to allow emojis when fixed in ldk
             invoiceExpiryDeltaSecs: UInt32(expiryDelta),
-            minFinalCltvExpiryDelta: nil //TOOD
+            minFinalCltvExpiryDelta: nil
         )
         
         if res.isOk() {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@synonymdev/react-native-ldk",
   "title": "React Native LDK",
-  "version": "0.0.120",
+  "version": "0.0.122",
   "description": "React Native wrapper for LDK",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
Gets more successful routing for shorter route payments setting base penalty as 500 sats.
Will come back and allow the whole score params object to be set from the JS side.