### PR TITLE
Async backups

### DIFF
--- a/lib/android/src/main/java/com/reactnativeldk/LdkModule.kt
+++ b/lib/android/src/main/java/com/reactnativeldk/LdkModule.kt
@@ -152,7 +152,6 @@ class LdkModule(reactContext: ReactApplicationContext) : ReactContextBaseJavaMod
     private val channelManagerPersister: LdkChannelManagerPersister by lazy { LdkChannelManagerPersister() }
 
     //Config required to setup below objects
-    private var chainMonitor: ChainMonitor? = null
     private var keysManager: KeysManager? = null
     private var channelManager: ChannelManager? = null
     private var userConfig: UserConfig? = null
@@ -173,6 +172,8 @@ class LdkModule(reactContext: ReactApplicationContext) : ReactContextBaseJavaMod
     companion object {
         lateinit var accountStoragePath: String
         lateinit var channelStoragePath: String
+
+        var chainMonitor: ChainMonitor? = null
     }
 
     init {
@@ -1023,7 +1024,7 @@ class LdkModule(reactContext: ReactApplicationContext) : ReactContextBaseJavaMod
             }
 
             if (remotePersist) {
-                BackupClient.persist(BackupClient.Label.MISC(fileName), file.readBytes())
+                BackupClient.addToPersistQueue(BackupClient.Label.MISC(fileName), file.readBytes())
             }
 
             handleResolve(promise, LdkCallbackResponses.file_write_success)

--- a/lib/android/src/main/java/com/reactnativeldk/classes/LdkChannelManagerPersister.kt
+++ b/lib/android/src/main/java/com/reactnativeldk/classes/LdkChannelManagerPersister.kt
@@ -173,10 +173,13 @@ class LdkChannelManagerPersister: ChannelManagerConstructor.EventHandler {
 
     override fun persist_manager(channel_manager_bytes: ByteArray?) {
         if (channel_manager_bytes != null && LdkModule.accountStoragePath != "") {
-            BackupClient.persist(BackupClient.Label.CHANNEL_MANAGER(), channel_manager_bytes, retry = 100)
+            BackupClient.addToPersistQueue(BackupClient.Label.CHANNEL_MANAGER(), channel_manager_bytes) {
+                LdkEventEmitter.send(EventTypes.native_log, "Remote persisted channel manager to disk")
+            }
+
             File(LdkModule.accountStoragePath + "/" + LdkFileNames.channel_manager.fileName).writeBytes(channel_manager_bytes)
 
-            LdkEventEmitter.send(EventTypes.native_log, "Persisted channel manager to disk")
+            LdkEventEmitter.send(EventTypes.native_log, "Locally persisted channel manager to disk")
             LdkEventEmitter.send(EventTypes.backup, "")
         }
     }

--- a/lib/ios/Classes/LdkChannelManagerPersister.swift
+++ b/lib/ios/Classes/LdkChannelManagerPersister.swift
@@ -127,7 +127,7 @@ class LdkChannelManagerPersister: Persister, ExtendedChannelManagerPersister {
             
             let paymentId = Data(paymentPathFailed.getPaymentId() ?? []).hexEncodedString()
             let paymentHash = Data(paymentPathFailed.getPaymentHash()).hexEncodedString()
-             
+            
             LdkEventEmitter.shared.send(
                 withEvent: .channel_manager_payment_path_failed,
                 body: [
@@ -256,8 +256,36 @@ class LdkChannelManagerPersister: Persister, ExtendedChannelManagerPersister {
             
             //Save to disk for TX history
             persistPaymentClaimed(body)
-        default:
-            LdkEventEmitter.shared.send(withEvent: .native_log, body: "ERROR: unknown LdkChannelManagerPersister.handle_event type")
+            return
+        case .BumpTransaction:
+            guard let bumpTransaction = event.getValueAsBumpTransaction() else {
+                return handleEventError(event)
+            }
+            
+            LdkEventEmitter.shared.send(withEvent: .native_log, body: "TODO📣: BumpTransaction")
+            
+            return
+        case .ProbeFailed:
+            LdkEventEmitter.shared.send(withEvent: .native_log, body: "Unused Persister event: ProbeFailed")
+            return
+        case .ProbeSuccessful:
+            LdkEventEmitter.shared.send(withEvent: .native_log, body: "Unused Persister event: ProbeSuccessful")
+            return
+        case .InvoiceRequestFailed:
+            LdkEventEmitter.shared.send(withEvent: .native_log, body: "Unused Persister event: InvoiceRequestFailed")
+            return
+        case .HTLCIntercepted:
+            LdkEventEmitter.shared.send(withEvent: .native_log, body: "Unused Persister event: HTLCIntercepted")
+            return
+        case .ChannelPending:
+            LdkEventEmitter.shared.send(withEvent: .native_log, body: "Unused Persister event: ChannelPending")
+            return
+        case .ChannelReady:
+            LdkEventEmitter.shared.send(withEvent: .native_log, body: "Unused Persister event: ChannelReady")
+            return
+        case .HTLCHandlingFailed:
+            LdkEventEmitter.shared.send(withEvent: .native_log, body: "Unused Persister event: HTLCHandlingFailed")
+            return
         }
     }
     
@@ -267,7 +295,9 @@ class LdkChannelManagerPersister: Persister, ExtendedChannelManagerPersister {
         }
         
         do {
-            try BackupClient.persist(.channelManager, channelManager.write(), retry: 100)
+            BackupClient.addToPersistQueue(.channelManager, channelManager.write()) {
+                LdkEventEmitter.shared.send(withEvent: .native_log, body: "Remote persisted channel manager")
+            }
 
             try Data(channelManager.write()).write(to: managerStorage)
             LdkEventEmitter.shared.send(withEvent: .native_log, body: "Persisted channel manager to disk")            

--- a/lib/ios/Classes/LdkPersist.swift
+++ b/lib/ios/Classes/LdkPersist.swift
@@ -9,25 +9,33 @@ import Foundation
 import LightningDevKit
 
 class LdkPersister: Persist {
-    private func handleChannel(_ channelId: OutPoint, _ data: ChannelMonitor) -> ChannelMonitorUpdateStatus {
-        let channelId = Data(channelId.toChannelId()).hexEncodedString()
+    private func handleChannel(_ channelId: OutPoint, _ data: ChannelMonitor, _ updateId: Bindings.MonitorUpdateId) -> ChannelMonitorUpdateStatus {
+        let channelIdHex = Data(channelId.toChannelId()).hexEncodedString()
         let body = [
-            "channel_id": channelId,
+            "channel_id": channelIdHex,
             "counterparty_node_id": Data(data.getCounterpartyNodeId() ?? []).hexEncodedString()
         ]
         
         do {
-            guard let channelStoragePath = Ldk.channelStoragePath?.appendingPathComponent("\(channelId).bin") else {
+            guard let channelStoragePath = Ldk.channelStoragePath?.appendingPathComponent("\(channelIdHex).bin") else {
                 throw "Channel storage path not set"
             }
             
             let isNew = !FileManager().fileExists(atPath: channelStoragePath.path)
                         
-            try BackupClient.persist(.channelMonitor(id: channelId), data.write(), retry: 100)
-            try Data(data.write()).write(to: channelStoragePath)
-            
-            LdkEventEmitter.shared.send(withEvent: .native_log, body: "Persisted channel (\(channelId)) to disk")
-            LdkEventEmitter.shared.send(withEvent: .backup, body: "")
+            BackupClient.addToPersistQueue(.channelMonitor(id: channelIdHex), data.write()) {
+                //Callback for when the persist queue queue entry is processed
+                try! Data(data.write()).write(to: channelStoragePath)
+                
+                //Update chainmonitor with successful persist
+                let res = Ldk.chainMonitor?.channelMonitorUpdated(fundingTxo: channelId, completedUpdateId: updateId)
+                if let error = res?.getError() {
+                    LdkEventEmitter.shared.send(withEvent: .native_log, body: "Error. Failed to update chain monitor for channel (\(channelIdHex)) Error \(error.getValueType()).")
+                } else {
+                    LdkEventEmitter.shared.send(withEvent: .native_log, body: "Persisted channel \(channelIdHex). Update ID: \(updateId.hash())")
+                    LdkEventEmitter.shared.send(withEvent: .backup, body: "") //TODO remove after old backup is deprecated
+                }
+            }
             
             if isNew {
                 LdkEventEmitter.shared.send(
@@ -36,18 +44,18 @@ class LdkPersister: Persist {
                 )
             }
             
-            return ChannelMonitorUpdateStatus.Completed
+            return ChannelMonitorUpdateStatus.InProgress
         } catch {
-            LdkEventEmitter.shared.send(withEvent: .native_log, body: "Error. Failed to persist channel (\(channelId)) to disk Error \(error.localizedDescription).")
+            LdkEventEmitter.shared.send(withEvent: .native_log, body: "Error. Failed to persist channel (\(channelIdHex)) to disk Error \(error.localizedDescription).")
             return ChannelMonitorUpdateStatus.UnrecoverableError
         }
     }
     
     override func persistNewChannel(channelId: Bindings.OutPoint, data: Bindings.ChannelMonitor, updateId: Bindings.MonitorUpdateId) -> Bindings.ChannelMonitorUpdateStatus {
-        return handleChannel(channelId, data)
+        return handleChannel(channelId, data, updateId)
     }
     
     override func updatePersistedChannel(channelId: Bindings.OutPoint, update: Bindings.ChannelMonitorUpdate, data: Bindings.ChannelMonitor, updateId: Bindings.MonitorUpdateId) -> Bindings.ChannelMonitorUpdateStatus {
-        return handleChannel(channelId, data)
+        return handleChannel(channelId, data, updateId)
     }
 }


### PR DESCRIPTION
Remote state persistence now happens in the background. This fixes crashes on iOS when moving app to background during persisting. Also should improve android performance.

- iOS performs backups on 3 dispatch queues. One for channel manager, channel monitors and misc. This ensures each backup is done in the correct order without grouped older ones ever completing before a newer persist so server always has the latest state.
- Android uses background threads, a backup queue and a locking mechanism to achieve the same thing.