### PR TITLE
Custom keys manager

### DIFF
--- a/backup-server/.npmrc
+++ b/backup-server/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/backup-server/package.json
+++ b/backup-server/package.json
@@ -3,6 +3,11 @@
   "version": "1.0.0",
   "description": "",
   "main": "index.js",
+  "engines": {
+    "npm": ">=8.0.0 <9.0.0",
+    "node": ">=19.0.0"
+  },
+  "engineStrict" : true,
   "scripts": {
     "start": "node index.js",
     "create-keypair": "node src/create-keypair.js",

--- a/example/Dev.tsx
+++ b/example/Dev.tsx
@@ -367,12 +367,14 @@ const Dev = (): ReactElement => {
 					/>
 
 					<Button
-						title={'Get Address Balance'}
+						title={'🤑Get Address Balance'}
 						onPress={async (): Promise<void> => {
 							setMessage('Getting Address Balance...');
-							const address = await getAddress();
+							const { address, publicKey } = await getAddress();
 							const balance = await getAddressBalance(address);
-							setMessage(`Balance: ${balance}`);
+							setMessage(
+								`address ${address}\npublicKey ${publicKey}\nBalance: ${balance}`,
+							);
 						}}
 					/>
 

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -375,7 +375,7 @@ PODS:
   - React-jsinspector (0.72.4)
   - React-logger (0.72.4):
     - glog
-  - react-native-ldk (0.0.123):
+  - react-native-ldk (0.0.124):
     - React
   - react-native-randombytes (3.6.1):
     - React-Core
@@ -723,7 +723,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: c7f826e40fa9cab5d37cab6130b1af237332b594
   React-jsinspector: aaed4cf551c4a1c98092436518c2d267b13a673f
   React-logger: da1ebe05ae06eb6db4b162202faeafac4b435e77
-  react-native-ldk: e242bbc0c8ca5356409e2e065b80364dadb270b6
+  react-native-ldk: 5ac636bea5e24c687a4a009a339d5ee82e8c8d0f
   react-native-randombytes: 421f1c7d48c0af8dbcd471b0324393ebf8fe7846
   react-native-tcp-socket: c1b7297619616b4c9caae6889bcb0aba78086989
   React-NativeModulesApple: edb5ace14f73f4969df6e7b1f3e41bef0012740f

--- a/example/ldk/index.ts
+++ b/example/ldk/index.ts
@@ -264,6 +264,9 @@ export const getTransactionData = async (
 export const getTransactionPosition = async ({
 	tx_hash,
 	height,
+}: {
+	tx_hash: string;
+	height: number;
 }): Promise<TTransactionPosition> => {
 	const response = await electrum.getTransactionMerkle({
 		tx_hash,

--- a/example/utils/helpers.ts
+++ b/example/utils/helpers.ts
@@ -197,10 +197,11 @@ export const getAddress = async (): Promise<IAddress> => {
 	const root = bip32.fromSeed(mnemonicSeed, network);
 	const keyPair = root.derivePath("m/84'/1'/0'/0/0");
 	const publicKey = keyPair.publicKey.toString('hex');
-	const address = bitcoin.payments.p2wpkh({
-		pubkey: keyPair.publicKey,
-		network,
-	}).address ?? '';
+	const address =
+		bitcoin.payments.p2wpkh({
+			pubkey: keyPair.publicKey,
+			network,
+		}).address ?? '';
 
 	return {
 		address,

--- a/example/utils/helpers.ts
+++ b/example/utils/helpers.ts
@@ -1,5 +1,9 @@
 import Keychain from 'react-native-keychain';
-import { TAccount, TAvailableNetworks } from '@synonymdev/react-native-ldk';
+import {
+	TAccount,
+	TAvailableNetworks,
+	IAddress,
+} from '@synonymdev/react-native-ldk';
 import { getItem, setItem } from '../ldk';
 import { EAccount } from './types';
 import { err, ok, Result } from './result';
@@ -184,7 +188,7 @@ export const getMnemonicPhraseFromSeed = (accountSeed: string): string => {
  * Returns a single test address used for channel closures.
  * @returns {Promise<string>}
  */
-export const getAddress = async (): Promise<string> => {
+export const getAddress = async (): Promise<IAddress> => {
 	const network = getNetwork(selectedNetwork);
 
 	const { seed: accountSeed } = await getAccount();
@@ -192,10 +196,20 @@ export const getAddress = async (): Promise<string> => {
 	const mnemonicSeed = await bip39.mnemonicToSeed(mnemonic);
 	const root = bip32.fromSeed(mnemonicSeed, network);
 	const keyPair = root.derivePath("m/84'/1'/0'/0/0");
-	return (
-		bitcoin.payments.p2wpkh({ pubkey: keyPair.publicKey, network }).address ??
-		''
-	);
+	const publicKey = keyPair.publicKey.toString('hex');
+	const witnessProgram = bitcoin.crypto
+		.hash160(Buffer.from(publicKey, 'hex'))
+		.toString('hex');
+	const witnessProgramVersion = 0;
+
+	return {
+		address:
+			bitcoin.payments.p2wpkh({ pubkey: keyPair.publicKey, network }).address ??
+			'',
+		publicKey,
+		witnessProgram,
+		witnessProgramVersion,
+	};
 };
 
 export const ldkNetwork = (network: TAvailableNetworks): ENetworks => {

--- a/lib/android/src/main/java/com/reactnativeldk/LdkModule.kt
+++ b/lib/android/src/main/java/com/reactnativeldk/LdkModule.kt
@@ -653,6 +653,10 @@ class LdkModule(reactContext: ReactApplicationContext) : ReactContextBaseJavaMod
                 return handleReject(promise, LdkErrors.channel_accept_fail, Error((error.err as APIError.APIMisuseError).err))
             }
 
+            if (error.err is APIError.ChannelUnavailable) {
+                return handleReject(promise, LdkErrors.channel_accept_fail, Error((error.err as APIError.ChannelUnavailable).err))
+            }
+
             return handleReject(promise, LdkErrors.channel_accept_fail, Error(error.err.toString()))
         }
 

--- a/lib/android/src/main/java/com/reactnativeldk/LdkModule.kt
+++ b/lib/android/src/main/java/com/reactnativeldk/LdkModule.kt
@@ -132,6 +132,7 @@ enum class LdkFileNames(val fileName: String) {
     scorer("scorer.bin"),
     paymentsClaimed("payments_claimed.json"),
     paymentsSent("payments_sent.json"),
+    channelsOpenedWithCustomKeysManager("channels_opened_with_custom_keys_manager.json"),
 }
 
 class LdkModule(reactContext: ReactApplicationContext) : ReactContextBaseJavaModule(reactContext) {

--- a/lib/android/src/main/java/com/reactnativeldk/classes/CustomKeysManager.kt
+++ b/lib/android/src/main/java/com/reactnativeldk/classes/CustomKeysManager.kt
@@ -1,0 +1,98 @@
+package com.reactnativeldk.classes
+
+import org.ldk.structs.KeysManager
+import org.ldk.structs.Option_u32Z
+import org.ldk.structs.Result_CVec_u8ZNoneZ
+import org.ldk.structs.Result_ShutdownScriptInvalidShutdownScriptZ
+import org.ldk.structs.Result_ShutdownScriptNoneZ
+import org.ldk.structs.Result_TransactionNoneZ
+import org.ldk.structs.Result_WriteableEcdsaChannelSignerDecodeErrorZ
+import org.ldk.structs.ShutdownScript
+import org.ldk.structs.SignerProvider
+import org.ldk.structs.SignerProvider.SignerProviderInterface
+import org.ldk.structs.SpendableOutputDescriptor
+import org.ldk.structs.TxOut
+import org.ldk.structs.WriteableEcdsaChannelSigner
+import org.ldk.util.UInt128
+import org.ldk.util.WitnessVersion
+
+class CustomKeysManager(
+    seed: ByteArray,
+    startingTimeSecs: Long,
+    startingTimeNanos: Int,
+    destinationScriptPublicKey: ByteArray,
+    witnessProgram: ByteArray,
+    witnessProgramVersion: Byte
+) {
+    val inner: KeysManager = KeysManager.of(seed, startingTimeSecs, startingTimeNanos)
+    val signerProvider: CustomSignerProvider = CustomSignerProvider()
+    val destinationScriptPublicKey: ByteArray = destinationScriptPublicKey
+    val witnessProgram: ByteArray = witnessProgram
+    val witnessProgramVersion: Byte = witnessProgramVersion
+
+    init {
+        signerProvider.customKeysManager = this
+    }
+
+    fun spend_spendable_outputs(
+        descriptors: Array<SpendableOutputDescriptor>,
+        outputs: Array<TxOut>,
+        changeDestinationScript: ByteArray,
+        feerateSatPer1000Weight: Int,
+        locktime: Option_u32Z
+    ): Result_TransactionNoneZ {
+        //TODO filter out static outputs
+        val onlyNonStatic: Array<SpendableOutputDescriptor> = descriptors.filter {
+            true //TODO
+        }.toTypedArray()
+
+        val res = inner.spend_spendable_outputs(
+            onlyNonStatic,
+            outputs,
+            changeDestinationScript,
+            feerateSatPer1000Weight,
+            locktime
+        )
+        return res
+    }
+}
+
+
+class CustomSignerProvider : SignerProviderInterface {
+    lateinit var customKeysManager: CustomKeysManager
+
+    override fun get_destination_script(): Result_CVec_u8ZNoneZ {
+        return Result_CVec_u8ZNoneZ.ok(customKeysManager.destinationScriptPublicKey)
+    }
+
+    override fun get_shutdown_scriptpubkey(): Result_ShutdownScriptNoneZ {
+        val res = ShutdownScript.new_witness_program(
+            WitnessVersion(customKeysManager.witnessProgramVersion),
+            customKeysManager.witnessProgram
+        )
+
+        return if (res.is_ok) {
+            Result_ShutdownScriptNoneZ.ok((res as Result_ShutdownScriptInvalidShutdownScriptZ.Result_ShutdownScriptInvalidShutdownScriptZ_OK).res)
+        } else {
+            Result_ShutdownScriptNoneZ.err()
+        }
+    }
+
+    override fun derive_channel_signer(
+        channel_value_satoshis: Long,
+        channel_keys_id: ByteArray?
+    ): WriteableEcdsaChannelSigner {
+        return customKeysManager.signerProvider.derive_channel_signer(
+            channel_value_satoshis,
+            channel_keys_id
+        )
+    }
+
+    override fun generate_channel_keys_id(p0: Boolean, p1: Long, p2: UInt128?): ByteArray {
+        return customKeysManager.signerProvider.generate_channel_keys_id(p0, p1, p2)
+    }
+
+    override fun read_chan_signer(p0: ByteArray?): Result_WriteableEcdsaChannelSignerDecodeErrorZ {
+        return customKeysManager.signerProvider.read_chan_signer(p0!!)
+    }
+}

--- a/lib/ios/Classes/CustomKeysManager.swift
+++ b/lib/ios/Classes/CustomKeysManager.swift
@@ -21,7 +21,7 @@ class CustomKeysManager {
         self.witnessProgram = witnessProgram
         self.witnessProgramVersion = witnessProgramVersion
         self.signerProvider = CustomSignerProvider()
-        self.signerProvider.myKeysManager = self
+        self.signerProvider.customKeysManager = self
     }
     
     // We drop all occurences of `SpendableOutputDescriptor::StaticOutput` (since they will be
@@ -48,15 +48,15 @@ class CustomKeysManager {
 }
 
 class CustomSignerProvider: SignerProvider {
-    weak var myKeysManager: CustomKeysManager?
+    weak var customKeysManager: CustomKeysManager?
  
     override func getDestinationScript() -> Bindings.Result_CVec_u8ZNoneZ {
-        let destinationScriptPublicKey = myKeysManager!.destinationScriptPublicKey
+        let destinationScriptPublicKey = customKeysManager!.destinationScriptPublicKey
         return Bindings.Result_CVec_u8ZNoneZ.initWithOk(o: destinationScriptPublicKey)
     }
     
     override func getShutdownScriptpubkey() -> Bindings.Result_ShutdownScriptNoneZ {
-        let res = ShutdownScript.newWitnessProgram(version: myKeysManager!.witnessProgramVersion, program: myKeysManager!.witnessProgram)
+        let res = ShutdownScript.newWitnessProgram(version: customKeysManager!.witnessProgramVersion, program: customKeysManager!.witnessProgram)
         if res.isOk() {
             return Bindings.Result_ShutdownScriptNoneZ.initWithOk(o: res.getValue()!)
         }
@@ -70,14 +70,14 @@ class CustomSignerProvider: SignerProvider {
     }
     
     override func deriveChannelSigner(channelValueSatoshis: UInt64, channelKeysId: [UInt8]) -> Bindings.WriteableEcdsaChannelSigner {
-        return myKeysManager!.inner.asSignerProvider().deriveChannelSigner(
+        return customKeysManager!.inner.asSignerProvider().deriveChannelSigner(
             channelValueSatoshis: channelValueSatoshis,
             channelKeysId: channelKeysId
         )
     }
     
     override func generateChannelKeysId(inbound: Bool, channelValueSatoshis: UInt64, userChannelId: [UInt8]) -> [UInt8] {
-        return myKeysManager!.inner.asSignerProvider().generateChannelKeysId(
+        return customKeysManager!.inner.asSignerProvider().generateChannelKeysId(
             inbound: inbound,
             channelValueSatoshis: channelValueSatoshis,
             userChannelId: userChannelId
@@ -85,6 +85,6 @@ class CustomSignerProvider: SignerProvider {
     }
     
     override func readChanSigner(reader: [UInt8]) -> Bindings.Result_WriteableEcdsaChannelSignerDecodeErrorZ {
-        return myKeysManager!.inner.asSignerProvider().readChanSigner(reader: reader)
+        return customKeysManager!.inner.asSignerProvider().readChanSigner(reader: reader)
     }
 }

--- a/lib/ios/Classes/CustomKeysManager.swift
+++ b/lib/ios/Classes/CustomKeysManager.swift
@@ -1,0 +1,90 @@
+//
+//  CustomKeysManager.swift
+//  react-native-ldk
+//
+//  Created by Jason van den Berg on 2023/12/01.
+//
+
+import Foundation
+import LightningDevKit
+
+class CustomKeysManager {
+    let inner: KeysManager
+    let signerProvider: CustomSignerProvider
+    let destinationScriptPublicKey: [UInt8]
+    let witnessProgram: [UInt8]
+    let witnessProgramVersion: UInt8
+    
+    init(seed: [UInt8], startingTimeSecs: UInt64, startingTimeNanos: UInt32, destinationScriptPublicKey: [UInt8], witnessProgram: [UInt8], witnessProgramVersion: UInt8) {
+        self.inner = KeysManager(seed: seed, startingTimeSecs: startingTimeSecs, startingTimeNanos: startingTimeNanos)
+        self.destinationScriptPublicKey = destinationScriptPublicKey
+        self.witnessProgram = witnessProgram
+        self.witnessProgramVersion = witnessProgramVersion
+        self.signerProvider = CustomSignerProvider()
+        self.signerProvider.myKeysManager = self
+    }
+    
+    // We drop all occurences of `SpendableOutputDescriptor::StaticOutput` (since they will be
+    // spendable by the on chain wallet if opened with custom shutdown script pubkey) and forward any other descriptors to
+    // `KeysManager::spend_spendable_outputs`.
+    func spendSpendableOutputs(descriptors: [SpendableOutputDescriptor], outputs: [Bindings.TxOut], changeDestinationScript: [UInt8], feerateSatPer1000Weight: UInt32, locktime: UInt32?) -> Result_TransactionNoneZ {
+        let onlyNonStatic: [SpendableOutputDescriptor] = descriptors.filter { desc in
+            if desc.getValueType() == .StaticOutput {
+                return false
+            }
+            
+            return true
+        }
+                
+        let res = self.inner.spendSpendableOutputs(
+            descriptors: onlyNonStatic,
+            outputs: outputs,
+            changeDestinationScript: changeDestinationScript,
+            feerateSatPer1000Weight: feerateSatPer1000Weight,
+            locktime: locktime
+        )
+        return res
+    }
+}
+
+class CustomSignerProvider: SignerProvider {
+    weak var myKeysManager: CustomKeysManager?
+ 
+    override func getDestinationScript() -> Bindings.Result_CVec_u8ZNoneZ {
+        let destinationScriptPublicKey = myKeysManager!.destinationScriptPublicKey
+        return Bindings.Result_CVec_u8ZNoneZ.initWithOk(o: destinationScriptPublicKey)
+    }
+    
+    override func getShutdownScriptpubkey() -> Bindings.Result_ShutdownScriptNoneZ {
+        let res = ShutdownScript.newWitnessProgram(version: myKeysManager!.witnessProgramVersion, program: myKeysManager!.witnessProgram)
+        if res.isOk() {
+            return Bindings.Result_ShutdownScriptNoneZ.initWithOk(o: res.getValue()!)
+        }
+        
+        LdkEventEmitter.shared.send(
+            withEvent: .native_log,
+            body: "Invalid shutdown script from CustomSignerProvider: \(Data(res.getError()?.getScript() ?? []).hexEncodedString())"
+        )
+        
+        return .initWithErr()
+    }
+    
+    override func deriveChannelSigner(channelValueSatoshis: UInt64, channelKeysId: [UInt8]) -> Bindings.WriteableEcdsaChannelSigner {
+        return myKeysManager!.inner.asSignerProvider().deriveChannelSigner(
+            channelValueSatoshis: channelValueSatoshis,
+            channelKeysId: channelKeysId
+        )
+    }
+    
+    override func generateChannelKeysId(inbound: Bool, channelValueSatoshis: UInt64, userChannelId: [UInt8]) -> [UInt8] {
+        return myKeysManager!.inner.asSignerProvider().generateChannelKeysId(
+            inbound: inbound,
+            channelValueSatoshis: channelValueSatoshis,
+            userChannelId: userChannelId
+        )
+    }
+    
+    override func readChanSigner(reader: [UInt8]) -> Bindings.Result_WriteableEcdsaChannelSignerDecodeErrorZ {
+        return myKeysManager!.inner.asSignerProvider().readChanSigner(reader: reader)
+    }
+}

--- a/lib/ios/Ldk.m
+++ b/lib/ios/Ldk.m
@@ -16,6 +16,9 @@ RCT_EXTERN_METHOD(writeToLogFile:(NSString *)line
 RCT_EXTERN_METHOD(initChainMonitor:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject)
 RCT_EXTERN_METHOD(initKeysManager:(NSString *)seed
+                  destinationScriptPublicKey:(NSString *)destinationScriptPublicKey
+                  witnessProgram:(NSString *)witnessProgram
+                  witnessProgramVersion:(NSInteger *)witnessProgramVersion                  
                   resolve:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject)
 RCT_EXTERN_METHOD(initUserConfig:(NSDictionary *)userConfig

--- a/lib/ios/Ldk.swift
+++ b/lib/ios/Ldk.swift
@@ -796,7 +796,7 @@ class Ldk: NSObject {
             ldkOutputs.append(TxOut(scriptPubkey: (d["script_pubkey"] as! String).hexaBytes, value: d["value"] as! UInt64))
         }
         
-        let res = keysManager.spendSpendableOutputs(
+        let res = keysManager.inner.spendSpendableOutputs(
             descriptors: ldkDescriptors,
             outputs: ldkOutputs,
             changeDestinationScript: String(changeDestinationScript).hexaBytes,

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@synonymdev/react-native-ldk",
   "title": "React Native LDK",
-  "version": "0.0.123",
+  "version": "0.0.124",
   "description": "React Native wrapper for LDK",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/lib/src/ldk.ts
+++ b/lib/src/ldk.ts
@@ -36,6 +36,7 @@ import {
 	TNodeSignReq,
 	TBackedUpFileList,
 	TDownloadScorer,
+	TInitKeysManager,
 } from './utils/types';
 import { extractPaymentRequest } from './utils/helpers';
 
@@ -85,11 +86,24 @@ class LDK {
 	 * Private key for node. Used to derive node public key. 32-byte entropy.
 	 * https://docs.rs/lightning/latest/lightning/chain/keysinterface/struct.KeysManager.html
 	 * @param seed
+	 * @param channelCloseDestinationScriptPublicKey
+	 * @param channelCloseWitnessProgram
+	 * @param channelCloseWitnessProgramVersion
 	 * @returns {Promise<Err<unknown> | Ok<Ok<string> | Err<string>>>}
 	 */
-	async initKeysManager(seed: string): Promise<Result<string>> {
+	async initKeysManager({
+		seed,
+		channelCloseDestinationScriptPublicKey,
+		channelCloseWitnessProgram,
+		channelCloseWitnessProgramVersion,
+	}: TInitKeysManager): Promise<Result<string>> {
 		try {
-			const res = await NativeLDK.initKeysManager(seed);
+			const res = await NativeLDK.initKeysManager(
+				seed,
+				channelCloseDestinationScriptPublicKey,
+				channelCloseWitnessProgram,
+				channelCloseWitnessProgramVersion,
+			);
 			this.writeDebugToLog('initKeysManager');
 			return ok(res);
 		} catch (e) {

--- a/lib/src/utils/helpers.ts
+++ b/lib/src/utils/helpers.ts
@@ -177,7 +177,8 @@ export const startParamCheck = async ({
 				);
 			}
 
-			const address = await getAddress();
+			//TODO validate entire object
+			const address = (await getAddress()).address;
 			if (typeof address !== 'string') {
 				return err('getAddress is not returning the expected data.');
 			}

--- a/lib/src/utils/types.ts
+++ b/lib/src/utils/types.ts
@@ -315,6 +315,13 @@ export type TDownloadScorer = {
 	skipHoursThreshold?: number;
 };
 
+export type TInitKeysManager = {
+	seed: string;
+	channelCloseDestinationScriptPublicKey: string;
+	channelCloseWitnessProgram: string;
+	channelCloseWitnessProgramVersion: number;
+};
+
 export type TInitNetworkGraphReq = {
 	network: ENetworks;
 	rapidGossipSyncUrl?: string;
@@ -567,7 +574,14 @@ export type TLdkStart = {
 	skipParamCheck?: boolean;
 };
 
-export type TGetAddress = () => Promise<string>;
+export interface IAddress {
+	address: string;
+	publicKey: string;
+	witnessProgram: string;
+	witnessProgramVersion: number;
+}
+
+export type TGetAddress = () => Promise<IAddress>;
 
 export type TGetScriptPubKeyHistory = (
 	address: string,


### PR DESCRIPTION
Outputs from channel closes now get spent directly to on chain wallet.

- Extends the default LDK keys manager so we can provide our own signer provider and overrides functions that return destination script and shutdown script pubkey.
- Existing sweeping logic is kept for channels opened prior to this update. Going forward as a new channel is opened the channel ID is appended to a file so when it comes time to sweep outputs from a channel close it will skip this sweeping step if the channel ID is found as the channel was opened with new adapted keys manager.
- `getAddress()` in JS needs to be adapted to return witness program and program version. Example app shows how. 