### PR TITLE
Relocate Witness Program Logic

### DIFF
--- a/example/utils/helpers.ts
+++ b/example/utils/helpers.ts
@@ -197,18 +197,14 @@ export const getAddress = async (): Promise<IAddress> => {
 	const root = bip32.fromSeed(mnemonicSeed, network);
 	const keyPair = root.derivePath("m/84'/1'/0'/0/0");
 	const publicKey = keyPair.publicKey.toString('hex');
-	const witnessProgram = bitcoin.crypto
-		.hash160(Buffer.from(publicKey, 'hex'))
-		.toString('hex');
-	const witnessProgramVersion = 0;
+	const address = bitcoin.payments.p2wpkh({
+		pubkey: keyPair.publicKey,
+		network,
+	}).address ?? '';
 
 	return {
-		address:
-			bitcoin.payments.p2wpkh({ pubkey: keyPair.publicKey, network }).address ??
-			'',
+		address,
 		publicKey,
-		witnessProgram,
-		witnessProgramVersion,
 	};
 };
 

--- a/lib/package.json
+++ b/lib/package.json
@@ -60,6 +60,7 @@
     "typescript": "^4.2.4"
   },
   "dependencies": {
+    "bech32": "^2.0.0",
     "bitcoinjs-lib": "^6.0.2"
   },
   "bugs": {

--- a/lib/src/utils/helpers.ts
+++ b/lib/src/utils/helpers.ts
@@ -1,6 +1,7 @@
 import { ENetworks, TLdkStart } from './types';
 import { err, ok, Result } from './result';
 import * as bitcoin from 'bitcoinjs-lib';
+import { bech32m } from 'bech32';
 import networks from './networks';
 /**
  * This method runs a check on each parameter passed to the start method
@@ -307,4 +308,27 @@ export const sleep = (ms = 1000): Promise<void> => {
 	return new Promise((resolve) => {
 		setTimeout(resolve, ms);
 	});
+};
+
+/**
+ * Returns if the provided string is a valid Bech32m encoded string (taproot/p2tr address) and if so, which network.
+ * @param {string} address
+ * @returns { isValid: boolean; network: ENetworks }
+ */
+export const isValidBech32mEncodedString = (
+	address: string,
+): { isValid: boolean; network: ENetworks } => {
+	try {
+		const decoded = bech32m.decode(address);
+		if (decoded.prefix === 'bc') {
+			return { isValid: true, network: ENetworks.mainnet };
+		} else if (decoded.prefix === 'tb') {
+			return { isValid: true, network: ENetworks.testnet };
+		} else if (decoded.prefix === 'bcrt') {
+			return { isValid: true, network: ENetworks.regtest };
+		}
+	} catch (error) {
+		return { isValid: false, network: ENetworks.mainnet };
+	}
+	return { isValid: false, network: ENetworks.mainnet };
 };

--- a/lib/src/utils/types.ts
+++ b/lib/src/utils/types.ts
@@ -577,8 +577,6 @@ export type TLdkStart = {
 export interface IAddress {
 	address: string;
 	publicKey: string;
-	witnessProgram: string;
-	witnessProgramVersion: number;
 }
 
 export type TGetAddress = () => Promise<IAddress>;


### PR DESCRIPTION
This PR:
- Moves `witnessProgram` logic to `lightning-manager.ts` from `getAddress`.
- Removes `witnessProgram` types from `IAddress`.
- Adds `bech32` as dependency in package.json.
- Adds `isValidBech32mEncodedString` to `helpers.ts`.

This update reduces the amount of logic required in the `getAddress` method for devs implementing this library, only requiring them to include an address and public key.