### PR TITLE
feat: allow for backing up any file to remote backup server

### DIFF
--- a/backup-server/src/server.js
+++ b/backup-server/src/server.js
@@ -16,7 +16,7 @@ const challenges = new Map(); // pubkey -> {challenge, expires}
 
 const signedMessagePrefix = 'react-native-ldk backup server auth:';
 
-let labels = [
+const ldkLabels = [
     'ping',
     'channel_manager',
     'channel_monitor',
@@ -29,6 +29,15 @@ let labels = [
     'payments_sent',
     'bolt11_invoices',
 ];
+const bitkitLabels = [
+    'bitkit_settings',
+    'bitkit_widgets',
+    'bitkit_metadata',
+    'bitkit_blocktank_orders',
+    'bitkit_slashtags_contacts',
+];
+const labels = [...ldkLabels, ...bitkitLabels];
+
 let networks = ['bitcoin', 'testnet', 'regtest', 'signet'];
 
 const version = 'v1';

--- a/example/Dev.tsx
+++ b/example/Dev.tsx
@@ -645,6 +645,46 @@ const Dev = (): ReactElement => {
 							setMessage(res.value);
 						}}
 					/>
+
+					<Button
+						title={'List backed up files'}
+						onPress={async (): Promise<void> => {
+							setMessage('Backing up...');
+							const res = await ldk.backupListFiles();
+							if (res.isErr()) {
+								setMessage(res.error.message);
+								return;
+							}
+
+							setMessage(JSON.stringify(res.value));
+						}}
+					/>
+
+					<Button
+						title={'Test file backup'}
+						onPress={async (): Promise<void> => {
+							setMessage('Backing up...');
+							const content = `look at me I'm a file ${Date().toString()}`;
+							const res = await ldk.backupFile('ping', content);
+							if (res.isErr()) {
+								setMessage(res.error.message);
+								return;
+							}
+
+							const res2 = await ldk.fetchBackupFile('ping');
+							if (res2.isErr()) {
+								setMessage(res2.error.message);
+								return;
+							}
+
+							if (res2.value !== content) {
+								setMessage('File backup failed');
+								return;
+							}
+
+							setMessage(`Retrieved remote content: "${res2.value}"`);
+						}}
+					/>
 				</View>
 			</ScrollView>
 

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -375,7 +375,7 @@ PODS:
   - React-jsinspector (0.72.4)
   - React-logger (0.72.4):
     - glog
-  - react-native-ldk (0.0.125):
+  - react-native-ldk (0.0.127):
     - React
   - react-native-randombytes (3.6.1):
     - React-Core
@@ -723,7 +723,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: c7f826e40fa9cab5d37cab6130b1af237332b594
   React-jsinspector: aaed4cf551c4a1c98092436518c2d267b13a673f
   React-logger: da1ebe05ae06eb6db4b162202faeafac4b435e77
-  react-native-ldk: c78b18c8c8fe218481721f7083e3e0f825aa957e
+  react-native-ldk: 4ab3d26d5e1356313c572814289cc516dc18dd88
   react-native-randombytes: 421f1c7d48c0af8dbcd471b0324393ebf8fe7846
   react-native-tcp-socket: c1b7297619616b4c9caae6889bcb0aba78086989
   React-NativeModulesApple: edb5ace14f73f4969df6e7b1f3e41bef0012740f

--- a/example/ldk/index.ts
+++ b/example/ldk/index.ts
@@ -149,6 +149,7 @@ export const setupLdk = async (
 				manually_accept_inbound_channels: true,
 			},
 			trustedZeroConfPeers: [peers.lnd.pubKey],
+			skipRemoteBackups: !backupServerDetails,
 		});
 
 		if (lmStart.isErr()) {

--- a/example/ldk/index.ts
+++ b/example/ldk/index.ts
@@ -109,6 +109,15 @@ export const setupLdk = async (
 			return err(storageRes.error);
 		}
 
+		const res = await ldk.backupSetup({
+			network: ldkNetwork(selectedNetwork),
+			seed: account.seed,
+			details: backupServerDetails!,
+		});
+		if (res.isErr()) {
+			return err(res.error);
+		}
+
 		const lmStart = await lm.start({
 			getBestBlock,
 			account,
@@ -140,7 +149,6 @@ export const setupLdk = async (
 				manually_accept_inbound_channels: true,
 			},
 			trustedZeroConfPeers: [peers.lnd.pubKey],
-			backupServerDetails,
 		});
 
 		if (lmStart.isErr()) {

--- a/example/tests/lnd.ts
+++ b/example/tests/lnd.ts
@@ -101,6 +101,19 @@ describe('LND', function () {
 			// seed: account.seed,
 		});
 		await profile.init();
+
+		// const res = await ldk.backupSetup({
+		// 	network: 'regtest',
+		// 	seed: profile.seed,
+		// 	details: {
+		// 		host: 'http://127.0.0.1:3003',
+		// 		serverPubKey:
+		// 			'0319c4ff23820afec0c79ce3a42031d7fef1dff78b7bdd69b5560684f3e1827675',
+		// 	},
+		// });
+		// if (res.isErr()) {
+		// 	throw res.error;
+		// }
 	});
 
 	afterEach(async function () {

--- a/example/tests/utils/test-profile.ts
+++ b/example/tests/utils/test-profile.ts
@@ -86,17 +86,8 @@ export default class TestProfile {
 			network: ldkNetwork(this.network),
 			// forceCloseOnStartup: { forceClose: true, broadcastLatestTx: false },
 			forceCloseOnStartup: undefined,
+			skipRemoteBackups: true,
 			// trustedZeroConfPeers: [],
-			backupServerDetails: {
-				host: 'https://blocktank.synonym.to/staging-backups-ldk',
-				serverPubKey:
-					'02c03b8b8c1b5500b622646867d99bf91676fac0f38e2182c91a9ff0d053a21d6d',
-			},
-			// backupServerDetails: {
-			// 	host: 'http://127.0.0.1:3003',
-			// 	serverPubKey:
-			// 		'0319c4ff23820afec0c79ce3a42031d7fef1dff78b7bdd69b5560684f3e1827675',
-			// },
 		};
 	};
 

--- a/lib/android/src/main/java/com/reactnativeldk/classes/BackupClient.kt
+++ b/lib/android/src/main/java/com/reactnativeldk/classes/BackupClient.kt
@@ -141,6 +141,10 @@ class BackupClient {
                 urlString += "&channelId=${label.channelId}"
             }
 
+            if (method == Method.LIST) {
+                urlString += "&fileGroup=ldk"
+            }
+
             return URL(urlString)
         }
 

--- a/lib/android/src/main/java/com/reactnativeldk/classes/LdkChannelManagerPersister.kt
+++ b/lib/android/src/main/java/com/reactnativeldk/classes/LdkChannelManagerPersister.kt
@@ -324,8 +324,6 @@ class LdkChannelManagerPersister: ChannelManagerConstructor.EventHandler {
         } catch (e: Exception) {
             LdkEventEmitter.send(EventTypes.native_log, "Error could not read existing ChannelOpenedWithNewCustomKeysManager")
         }
-
-        println("**** existingIds: $existingIds")
     }
 
     private fun channelWasOpenedWithNewCustomKeysManager(channelId: ByteArray): Boolean {

--- a/lib/android/src/main/java/com/reactnativeldk/classes/LdkChannelManagerPersister.kt
+++ b/lib/android/src/main/java/com/reactnativeldk/classes/LdkChannelManagerPersister.kt
@@ -185,14 +185,16 @@ class LdkChannelManagerPersister: ChannelManagerConstructor.EventHandler {
 
     override fun persist_manager(channel_manager_bytes: ByteArray?) {
         if (channel_manager_bytes != null && LdkModule.accountStoragePath != "") {
-            BackupClient.addToPersistQueue(BackupClient.Label.CHANNEL_MANAGER(), channel_manager_bytes) {
-                LdkEventEmitter.send(EventTypes.native_log, "Remote persisted channel manager to disk")
+            BackupClient.addToPersistQueue(BackupClient.Label.CHANNEL_MANAGER(), channel_manager_bytes) { error ->
+                if (error != null) {
+                    LdkEventEmitter.send(EventTypes.native_log, "Failed to remotely persist channel manager to disk")
+                } else {
+                    LdkEventEmitter.send(EventTypes.native_log, "Remote persisted channel manager to disk")
+                }
             }
 
             File(LdkModule.accountStoragePath + "/" + LdkFileNames.channel_manager.fileName).writeBytes(channel_manager_bytes)
-
             LdkEventEmitter.send(EventTypes.native_log, "Locally persisted channel manager to disk")
-            LdkEventEmitter.send(EventTypes.backup, "")
         }
     }
 

--- a/lib/android/src/main/java/com/reactnativeldk/classes/LdkPersister.kt
+++ b/lib/android/src/main/java/com/reactnativeldk/classes/LdkPersister.kt
@@ -32,7 +32,12 @@ class LdkPersister {
                 return ChannelMonitorUpdateStatus.LDKChannelMonitorUpdateStatus_Completed
             }
 
-            BackupClient.addToPersistQueue(BackupClient.Label.CHANNEL_MONITOR(channelId=channelId), data.write()) {
+            BackupClient.addToPersistQueue(BackupClient.Label.CHANNEL_MONITOR(channelId=channelId), data.write()) { error ->
+                if (error != null) {
+                    LdkEventEmitter.send(EventTypes.native_log, "Failed to persist channel (${id.to_channel_id().hexEncodedString()}) to remote backup: $error")
+                    return@addToPersistQueue
+                }
+
                 try {
                     file.writeBytes(data.write())
                 } catch (e: Exception) {

--- a/lib/ios/Classes/BackupClient.swift
+++ b/lib/ios/Classes/BackupClient.swift
@@ -393,7 +393,7 @@ class BackupClient {
     
     static func retrieveCompleteBackup() throws -> CompleteBackup {
         let backedUpFilenames = try listFiles()
-        
+                
         var allFiles: [String: Data] = [:]
         var channelFiles: [String: Data] = [:]
 
@@ -586,9 +586,9 @@ class BackupClient {
 
 //Backup queue management
 extension BackupClient {
-    static func addToPersistQueue(_ label: Label, _ bytes: [UInt8], callback: (() -> Void)? = nil) {
+    static func addToPersistQueue(_ label: Label, _ bytes: [UInt8], callback: ((Error?) -> Void)? = nil) {
         guard !skipRemoteBackup else {
-            callback?()
+            callback?(nil)
             LdkEventEmitter.shared.send(withEvent: .native_log, body: "Skipping remote backup queue append for \(label.string)")
             return
         }
@@ -618,9 +618,10 @@ extension BackupClient {
         backupQueue.async {
             do {
                 try persist(label, bytes, retry: 10)
-                callback?()
+                callback?(nil)
             } catch {
-                LdkEventEmitter.shared.send(withEvent: .native_log, body: "Failed to persist channel manager backup. \(error.localizedDescription)")
+                LdkEventEmitter.shared.send(withEvent: .native_log, body: "Failed to persist remote backup \(label.string). \(error.localizedDescription)")
+                callback?(error)
             }
         }
     }

--- a/lib/ios/Classes/BackupClient.swift
+++ b/lib/ios/Classes/BackupClient.swift
@@ -145,6 +145,12 @@ class BackupClient {
             urlString = "\(urlString)&channelId=\(id)"
         }
         
+        //Only include files related to this library
+        if method == .list {
+            //TODO add this to android
+            urlString = "\(urlString)&fileGroup=ldk"
+        }
+        
         return URL(string: urlString)!
     }
     

--- a/lib/ios/Classes/LdkChannelManagerPersister.swift
+++ b/lib/ios/Classes/LdkChannelManagerPersister.swift
@@ -312,10 +312,14 @@ class LdkChannelManagerPersister: Persister, ExtendedChannelManagerPersister {
         guard let managerStorage = Ldk.accountStoragePath?.appendingPathComponent(LdkFileNames.channel_manager.rawValue) else {
             return Result_NoneIOErrorZ.initWithErr(e: .Other)
         }
-        
+                
         do {
-            BackupClient.addToPersistQueue(.channelManager, channelManager.write()) {
-                LdkEventEmitter.shared.send(withEvent: .native_log, body: "Remote persisted channel manager")
+            BackupClient.addToPersistQueue(.channelManager, channelManager.write()) { error in
+                if let error {
+                    LdkEventEmitter.shared.send(withEvent: .native_log, body: "Failed to remote persist channel manager Error: \(error.localizedDescription)")
+                } else {
+                    LdkEventEmitter.shared.send(withEvent: .native_log, body: "Remote persisted channel manager")
+                }
             }
             
             try Data(channelManager.write()).write(to: managerStorage)

--- a/lib/ios/Classes/LdkChannelManagerPersister.swift
+++ b/lib/ios/Classes/LdkChannelManagerPersister.swift
@@ -320,9 +320,7 @@ class LdkChannelManagerPersister: Persister, ExtendedChannelManagerPersister {
             
             try Data(channelManager.write()).write(to: managerStorage)
             LdkEventEmitter.shared.send(withEvent: .native_log, body: "Persisted channel manager to disk")
-            
-            LdkEventEmitter.shared.send(withEvent: .backup, body: "")
-            
+                        
             return Result_NoneIOErrorZ.initWithOk()
         } catch {
             LdkEventEmitter.shared.send(withEvent: .native_log, body: "Error. Failed to persist channel manager to disk Error \(error.localizedDescription).")

--- a/lib/ios/Classes/LdkPersist.swift
+++ b/lib/ios/Classes/LdkPersist.swift
@@ -39,7 +39,6 @@ class LdkPersister: Persist {
                     LdkEventEmitter.shared.send(withEvent: .native_log, body: "Error. Failed to update chain monitor for channel (\(channelIdHex)) Error \(error.getValueType()).")
                 } else {
                     LdkEventEmitter.shared.send(withEvent: .native_log, body: "Persisted channel \(channelIdHex). Update ID: \(updateId.hash())")
-                    LdkEventEmitter.shared.send(withEvent: .backup, body: "") //TODO remove after old backup is deprecated
                 }
             }
             

--- a/lib/ios/Classes/LdkPersist.swift
+++ b/lib/ios/Classes/LdkPersist.swift
@@ -32,7 +32,6 @@ class LdkPersister: Persist {
                 return ChannelMonitorUpdateStatus.Completed
             }
                          
-            //TODO skip this and return ChannelMonitorUpdateStatus.Completed when saved locally if remote backups not setup
             BackupClient.addToPersistQueue(.channelMonitor(id: channelIdHex), data.write()) { error in
                 if let error {
                     LdkEventEmitter.shared.send(withEvent: .native_log, body: "Error. Failed persist channel on remote server (\(channelIdHex)). \(error.localizedDescription)")

--- a/lib/ios/Ldk.m
+++ b/lib/ios/Ldk.m
@@ -187,7 +187,13 @@ RCT_EXTERN_METHOD(backupSelfCheck:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject)
 RCT_EXTERN_METHOD(backupListFiles:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject)
-
+RCT_EXTERN_METHOD(backupFile:(NSString *)fileName
+                  content:(NSString *)content
+                  resolve:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject)
+RCT_EXTERN_METHOD(fetchBackupFile:(NSString *)fileName
+                  resolve:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject)
 @end
 
 //MARK: Events

--- a/lib/ios/Ldk.swift
+++ b/lib/ios/Ldk.swift
@@ -8,7 +8,6 @@ enum EventTypes: String, CaseIterable {
     case register_tx = "register_tx"
     case register_output = "register_output"
     case broadcast_transaction = "broadcast_transaction"
-    case backup = "backup"
     case channel_manager_funding_generation_ready = "channel_manager_funding_generation_ready"
     case channel_manager_payment_claimable = "channel_manager_payment_claimable"
     case channel_manager_payment_sent = "channel_manager_payment_sent"

--- a/lib/ios/Ldk.swift
+++ b/lib/ios/Ldk.swift
@@ -72,6 +72,7 @@ enum LdkErrors: String {
     case backup_restore_failed = "backup_restore_failed"
     case backup_restore_failed_existing_files = "backup_restore_failed_existing_files"
     case backup_list_files_failed = "backup_list_files_failed"
+    case backup_fetch_file_failed = "backup_fetch_file_failed"
     case scorer_download_fail = "scorer_download_fail"
 }
 
@@ -101,6 +102,7 @@ enum LdkCallbackResponses: String {
     case backup_client_setup_success = "backup_client_setup_success"
     case backup_restore_success = "backup_restore_success"
     case backup_client_check_success = "backup_client_check_success"
+    case backup_file_success = "backup_file_success"
     case scorer_download_success = "scorer_download_success"
     case scorer_download_skip = "scorer_download_skip"
 }
@@ -1383,6 +1385,41 @@ class Ldk: NSObject {
             ])
         } catch {
             handleReject(reject, .backup_list_files_failed, error, error.localizedDescription)
+        }
+    }
+    
+    @objc
+    func backupFile(_ fileName: NSString, content: NSString, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+        guard !BackupClient.requiresSetup else {
+            return handleReject(reject, .backup_setup_required)
+        }
+        
+        guard let data = String(content).data(using: .utf8) else {
+            return
+        }
+        
+        let bytes = [UInt8](data)
+            
+        BackupClient.addToPersistQueue(.misc(fileName: String(fileName)), bytes) { error in
+            if let error {
+                handleReject(reject, .backup_list_files_failed, error, error.localizedDescription)
+                return
+            }
+            handleResolve(resolve, .backup_file_success)
+        }
+    }
+    
+    @objc
+    func fetchBackupFile(_ fileName: NSString, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+        guard !BackupClient.requiresSetup else {
+            return handleReject(reject, .backup_setup_required)
+        }
+            
+        do {
+            let data = try BackupClient.retrieve(.misc(fileName: String(fileName)))
+            resolve(String.init(data: data, encoding: .utf8))
+        } catch {
+            handleReject(reject, .backup_fetch_file_failed, error, error.localizedDescription)
         }
     }
 }

--- a/lib/ios/Ldk.swift
+++ b/lib/ios/Ldk.swift
@@ -73,6 +73,7 @@ enum LdkErrors: String {
     case backup_restore_failed_existing_files = "backup_restore_failed_existing_files"
     case backup_list_files_failed = "backup_list_files_failed"
     case backup_fetch_file_failed = "backup_fetch_file_failed"
+    case backup_file_failed = "backup_file_failed"
     case scorer_download_fail = "scorer_download_fail"
 }
 
@@ -1402,7 +1403,7 @@ class Ldk: NSObject {
             
         BackupClient.addToPersistQueue(.misc(fileName: String(fileName)), bytes) { error in
             if let error {
-                handleReject(reject, .backup_list_files_failed, error, error.localizedDescription)
+                handleReject(reject, .backup_file_failed, error, error.localizedDescription)
                 return
             }
             handleResolve(resolve, .backup_file_success)

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@synonymdev/react-native-ldk",
   "title": "React Native LDK",
-  "version": "0.0.126",
+  "version": "0.0.127",
   "description": "React Native wrapper for LDK",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/lib/src/ldk.ts
+++ b/lib/src/ldk.ts
@@ -1314,6 +1314,24 @@ class LDK {
 			return err(e);
 		}
 	}
+
+	async backupFile(fileName: string, content: string): Promise<Result<string>> {
+		try {
+			const res = await NativeLDK.backupFile(fileName, content);
+			return ok(res);
+		} catch (e) {
+			return err(e);
+		}
+	}
+
+	async fetchBackupFile(fileName: string): Promise<Result<string>> {
+		try {
+			const res = await NativeLDK.fetchBackupFile(fileName);
+			return ok(res);
+		} catch (e) {
+			return err(e);
+		}
+	}
 }
 
 export default new LDK();

--- a/lib/src/ldk.ts
+++ b/lib/src/ldk.ts
@@ -1294,7 +1294,7 @@ class LDK {
 	/**
 	 * Runs a self check by creating random string, encrypting, backing up, fetching, decrypting and validating content.
 	 */
-	async backupSelfCheck(): Promise<Result<boolean>> {
+	async backupSelfCheck(): Promise<Result<string>> {
 		try {
 			const res = await NativeLDK.backupSelfCheck();
 			return ok(res);

--- a/lib/src/lightning-manager.ts
+++ b/lib/src/lightning-manager.ts
@@ -146,8 +146,6 @@ class LightningManager {
 	private pendingStartPromises: Array<(result: Result<string>) => void> = [];
 	private previousAccountName: string = '';
 
-	private backupsServerSetup = false;
-
 	constructor() {
 		// Step 0: Subscribe to all events
 		ldk.onEvent(EEventTypes.native_log, (line) => {
@@ -291,8 +289,8 @@ class LightningManager {
 		forceCloseOnStartup,
 		userConfig = defaultUserConfig,
 		trustedZeroConfPeers = [],
-		backupServerDetails,
 		skipParamCheck = false,
+		skipRemoteBackups = false,
 	}: TLdkStart): Promise<Result<string>> {
 		if (!account) {
 			return err(
@@ -456,15 +454,8 @@ class LightningManager {
 			);
 		}
 
-		if (backupServerDetails) {
-			promises.push(
-				ldk.backupSetup({
-					seed: account.seed,
-					network: this.network,
-					details: backupServerDetails,
-				}),
-			);
-			this.backupsServerSetup = true;
+		if (!skipRemoteBackups) {
+			promises.push(ldk.backupSelfCheck());
 		}
 
 		// Check for any errors before starting channel manager.

--- a/lib/src/utils/types.ts
+++ b/lib/src/utils/types.ts
@@ -17,7 +17,6 @@ export enum EEventTypes {
 	register_tx = 'register_tx',
 	register_output = 'register_output',
 	broadcast_transaction = 'broadcast_transaction',
-	backup = 'backup',
 	channel_manager_funding_generation_ready = 'channel_manager_funding_generation_ready',
 	channel_manager_payment_claimable = 'channel_manager_payment_claimable',
 	channel_manager_payment_sent = 'channel_manager_payment_sent',
@@ -34,7 +33,6 @@ export enum EEventTypes {
 	new_channel = 'new_channel',
 	network_graph_updated = 'network_graph_updated',
 	channel_manager_restarted = 'channel_manager_restarted',
-	backup_failed = 'backup_failed',
 }
 
 //LDK event responses
@@ -493,6 +491,7 @@ export enum ELdkData {
 	bolt11_invoices = 'bolt11_invoices',
 }
 
+//Can be removed after importAccount is officially removed
 export type TLdkData = {
 	[ELdkData.channel_manager]: string;
 	[ELdkData.channel_monitors]: { [key: string]: string };
@@ -507,6 +506,7 @@ export type TLdkData = {
 	[ELdkData.bolt11_invoices]: TBolt11Invoices;
 };
 
+//Can be removed after importAccount is officially removed
 export type TAccountBackup = {
 	account: TAccount;
 	package_version: string;
@@ -530,20 +530,6 @@ export type TLdkPaymentIds = string[];
 export type TBolt11Invoices = string[];
 
 export type TLdkSpendableOutputs = string[];
-
-export const DefaultLdkDataShape: TLdkData = {
-	[ELdkData.channel_manager]: '',
-	[ELdkData.channel_monitors]: {},
-	[ELdkData.peers]: [],
-	[ELdkData.unconfirmed_transactions]: [],
-	[ELdkData.broadcasted_transactions]: [],
-	[ELdkData.payment_ids]: [],
-	[ELdkData.timestamp]: 0,
-	[ELdkData.spendable_outputs]: [],
-	[ELdkData.payments_claimed]: [],
-	[ELdkData.payments_sent]: [],
-	[ELdkData.bolt11_invoices]: [],
-};
 
 export type TAccount = {
 	name: string;

--- a/lib/src/utils/types.ts
+++ b/lib/src/utils/types.ts
@@ -556,8 +556,8 @@ export type TLdkStart = {
 	forceCloseOnStartup?: TForceCloseOnStartup;
 	userConfig?: TUserConfig;
 	trustedZeroConfPeers?: string[];
-	backupServerDetails?: TBackupServerDetails;
 	skipParamCheck?: boolean;
+	skipRemoteBackups?: boolean;
 };
 
 export interface IAddress {


### PR DESCRIPTION
- Allows for backing up and retrieving other non LDK related files
- Cleans up old event based backup logic but still keeps import function to allow older backups to be restore
- Removes backup setup outside of lm.start so apps need to call this first. Makes it more flexible as it can be used without starting LDK.
- Fixes a crash that happens when app is used without remote backups