### PR TITLE
Backup fixes

### DIFF
--- a/backup-server/src/server.js
+++ b/backup-server/src/server.js
@@ -28,6 +28,7 @@ const ldkLabels = [
     'payments_claimed',
     'payments_sent',
     'bolt11_invoices',
+    'channel_opened_with_custom_keys_manager'
 ];
 const bitkitLabels = [
     'bitkit_settings',

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -375,7 +375,7 @@ PODS:
   - React-jsinspector (0.72.4)
   - React-logger (0.72.4):
     - glog
-  - react-native-ldk (0.0.127):
+  - react-native-ldk (0.0.128):
     - React
   - react-native-randombytes (3.6.1):
     - React-Core
@@ -723,7 +723,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: c7f826e40fa9cab5d37cab6130b1af237332b594
   React-jsinspector: aaed4cf551c4a1c98092436518c2d267b13a673f
   React-logger: da1ebe05ae06eb6db4b162202faeafac4b435e77
-  react-native-ldk: 4ab3d26d5e1356313c572814289cc516dc18dd88
+  react-native-ldk: 7e754f4168e774326eaf2f0707843f5ce06f70bb
   react-native-randombytes: 421f1c7d48c0af8dbcd471b0324393ebf8fe7846
   react-native-tcp-socket: c1b7297619616b4c9caae6889bcb0aba78086989
   React-NativeModulesApple: edb5ace14f73f4969df6e7b1f3e41bef0012740f

--- a/lib/android/src/main/java/com/reactnativeldk/LdkModule.kt
+++ b/lib/android/src/main/java/com/reactnativeldk/LdkModule.kt
@@ -1258,7 +1258,15 @@ class LdkModule(reactContext: ReactApplicationContext) : ReactContextBaseJavaMod
 
             val completeBackup = BackupClient.retrieveCompleteBackup()
             for (file in completeBackup.files) {
-                val newFile = File(accountStoragePath + "/" + file.key)
+                val key = file.key.replace(".bin", "")
+                var fileName = "$key.json"
+
+                val ldkFileName = LdkFileNames.values().firstOrNull { it.fileName.contains(key) }
+                if (ldkFileName != null) {
+                    fileName = ldkFileName.fileName
+                }
+
+                val newFile = File(accountStoragePath + "/" + fileName)
                 newFile.writeBytes(file.value)
             }
 

--- a/lib/android/src/main/java/com/reactnativeldk/LdkModule.kt
+++ b/lib/android/src/main/java/com/reactnativeldk/LdkModule.kt
@@ -133,7 +133,7 @@ enum class LdkFileNames(val fileName: String) {
     scorer("scorer.bin"),
     paymentsClaimed("payments_claimed.json"),
     paymentsSent("payments_sent.json"),
-    channelsOpenedWithCustomKeysManager("channels_opened_with_custom_keys_manager.json"),
+    channelOpenedWithCustomKeysManager("channel_opened_with_custom_keys_manager.json"),
 }
 
 class LdkModule(reactContext: ReactApplicationContext) : ReactContextBaseJavaModule(reactContext) {
@@ -502,6 +502,23 @@ class LdkModule(reactContext: ReactApplicationContext) : ReactContextBaseJavaMod
         currentBlockchainHeight = blockHeight
 
         handleResolve(promise, LdkCallbackResponses.channel_manager_init_success)
+
+        //TODO remove after a few updates
+        //Temp function as original file was named incorrectly and doesn't match ios or backup server
+        //*******************************
+        if (accountStoragePath != "") {
+            val wrongName = "channels_opened_with_custom_keys_manager.json"
+            val correctName = LdkFileNames.channelOpenedWithCustomKeysManager.fileName
+            try {
+                if (File(accountStoragePath + "/" + wrongName).exists()) {
+                    File(accountStoragePath + "/" + wrongName).renameTo(File(accountStoragePath + "/" + correctName))
+                    BackupClient.addToPersistQueue(BackupClient.Label.MISC(correctName), File(accountStoragePath + "/" + correctName).readBytes())
+                }
+            } catch (e: Exception) {
+                LdkEventEmitter.send(EventTypes.native_log, "Error could not rename channel list file")
+            }
+        }
+        //*******************************
     }
     @ReactMethod
     fun restart(promise: Promise) {

--- a/lib/android/src/main/java/com/reactnativeldk/classes/LdkChannelManagerPersister.kt
+++ b/lib/android/src/main/java/com/reactnativeldk/classes/LdkChannelManagerPersister.kt
@@ -253,6 +253,7 @@ class LdkChannelManagerPersister: ChannelManagerConstructor.EventHandler {
             payments = payments.plus(payment.toHashMap())
         }
 
+        BackupClient.addToPersistQueue(BackupClient.Label.MISC(LdkFileNames.paymentsClaimed.fileName), JSONArray(payments).toString().toByteArray())
         File(LdkModule.accountStoragePath + "/" + LdkFileNames.paymentsClaimed.fileName).writeText(JSONArray(payments).toString())
     }
 
@@ -296,6 +297,7 @@ class LdkChannelManagerPersister: ChannelManagerConstructor.EventHandler {
             payments = payments.plus(payment)
         }
 
+        BackupClient.addToPersistQueue(BackupClient.Label.MISC(LdkFileNames.paymentsSent.fileName), JSONArray(payments).toString().toByteArray())
         File(LdkModule.accountStoragePath + "/" + LdkFileNames.paymentsSent.fileName).writeText(JSONArray(payments).toString())
     }
 
@@ -310,8 +312,8 @@ class LdkChannelManagerPersister: ChannelManagerConstructor.EventHandler {
         val id = channelId.hexEncodedString()
         val existingIds = ArrayList<String>()
         try {
-            if (File(LdkModule.accountStoragePath + "/" + LdkFileNames.channelsOpenedWithCustomKeysManager.fileName).exists()) {
-                val data = File(LdkModule.accountStoragePath + "/" + LdkFileNames.channelsOpenedWithCustomKeysManager.fileName).readBytes()
+            if (File(LdkModule.accountStoragePath + "/" + LdkFileNames.channelOpenedWithCustomKeysManager.fileName).exists()) {
+                val data = File(LdkModule.accountStoragePath + "/" + LdkFileNames.channelOpenedWithCustomKeysManager.fileName).readBytes()
                 val existingIdsArray = JSONArray(String(data))
                 for (i in 0 until existingIdsArray.length()) {
                     existingIds.add(existingIdsArray.getString(i))
@@ -321,7 +323,9 @@ class LdkChannelManagerPersister: ChannelManagerConstructor.EventHandler {
             if (!existingIds.contains(id)) {
                 existingIds.add(id)
 
-                File(LdkModule.accountStoragePath + "/" + LdkFileNames.channelsOpenedWithCustomKeysManager.fileName).writeText(JSONArray(existingIds).toString())
+                File(LdkModule.accountStoragePath + "/" + LdkFileNames.channelOpenedWithCustomKeysManager.fileName).writeText(JSONArray(existingIds).toString())
+
+                BackupClient.addToPersistQueue(BackupClient.Label.MISC(LdkFileNames.channelOpenedWithCustomKeysManager.fileName), JSONArray(existingIds).toString().toByteArray())
             }
         } catch (e: Exception) {
             LdkEventEmitter.send(EventTypes.native_log, "Error could not read existing ChannelOpenedWithNewCustomKeysManager")
@@ -337,8 +341,8 @@ class LdkChannelManagerPersister: ChannelManagerConstructor.EventHandler {
         val id = channelId.hexEncodedString()
         val existingIds = ArrayList<String>()
         try {
-            if (File(LdkModule.accountStoragePath + "/" + LdkFileNames.channelsOpenedWithCustomKeysManager.fileName).exists()) {
-                val data = File(LdkModule.accountStoragePath + "/" + LdkFileNames.channelsOpenedWithCustomKeysManager.fileName).readBytes()
+            if (File(LdkModule.accountStoragePath + "/" + LdkFileNames.channelOpenedWithCustomKeysManager.fileName).exists()) {
+                val data = File(LdkModule.accountStoragePath + "/" + LdkFileNames.channelOpenedWithCustomKeysManager.fileName).readBytes()
                 val existingIdsArray = JSONArray(String(data))
                 for (i in 0 until existingIdsArray.length()) {
                     existingIds.add(existingIdsArray.getString(i))

--- a/lib/ios/Classes/LdkChannelManagerPersister.swift
+++ b/lib/ios/Classes/LdkChannelManagerPersister.swift
@@ -410,6 +410,8 @@ class LdkChannelManagerPersister: Persister, ExtendedChannelManagerPersister {
             }
             
             try jsonString.write(to: claimedPaymentsStorage, atomically: true, encoding: .utf8)
+            
+            BackupClient.addToPersistQueue(.misc(fileName: LdkFileNames.paymentsClaimed.rawValue), [UInt8](jsonData))
         } catch {
             LdkEventEmitter.shared.send(withEvent: .native_log, body: "Error writing payment claimed to file: \(error)")
         }
@@ -462,6 +464,8 @@ class LdkChannelManagerPersister: Persister, ExtendedChannelManagerPersister {
             }
             
             try jsonString.write(to: sentPaymentsStorage, atomically: true, encoding: .utf8)
+            
+            BackupClient.addToPersistQueue(.misc(fileName: LdkFileNames.paymentsSent.rawValue), [UInt8](jsonData))
         } catch {
             LdkEventEmitter.shared.send(withEvent: .native_log, body: "Error writing payment sent to file: \(error)")
         }
@@ -504,6 +508,8 @@ class LdkChannelManagerPersister: Persister, ExtendedChannelManagerPersister {
                 }
                 
                 try jsonString.write(to: channelIdStorage, atomically: true, encoding: .utf8)
+                
+                BackupClient.addToPersistQueue(.misc(fileName: LdkFileNames.channelsOpenedWithCustomKeysManager.rawValue), [UInt8](jsonData))
             }
         } catch {
             LdkEventEmitter.shared.send(withEvent: .native_log, body: "Error could not read existing ChannelOpenedWithNewCustomKeysManager")

--- a/lib/ios/Ldk.swift
+++ b/lib/ios/Ldk.swift
@@ -108,7 +108,7 @@ enum LdkCallbackResponses: String {
     case scorer_download_skip = "scorer_download_skip"
 }
 
-enum LdkFileNames: String {
+enum LdkFileNames: String, CaseIterable {
     case network_graph = "network_graph.bin"
     case channel_manager = "channel_manager.bin"
     case scorer = "scorer.bin"
@@ -1338,7 +1338,7 @@ class Ldk: NSObject {
         guard let channelStoragePath = Ldk.channelStoragePath else {
             return handleReject(reject, .init_storage_path)
         }
-        
+                
         do {
             if !overwrite {
                 let fileManager = FileManager.default
@@ -1358,7 +1358,15 @@ class Ldk: NSObject {
             let completeBackup = try BackupClient.retrieveCompleteBackup()
             
             for file in completeBackup.files {
-                try file.value.write(to: accountStoragePath.appendingPathComponent(file.key))
+                //Decide if .json or .bin by checking enum
+                let key = file.key.replacingOccurrences(of: ".bin", with: "")
+                var fileName = "\(key).json"
+                
+                if let ldkFileName = LdkFileNames.allCases.first(where: { $0.rawValue.contains(key) }) {
+                    fileName = ldkFileName.rawValue
+                }
+
+                try file.value.write(to: accountStoragePath.appendingPathComponent(fileName))
             }
             
             for channel in completeBackup.channelFiles {

--- a/lib/ios/Ldk.swift
+++ b/lib/ios/Ldk.swift
@@ -496,6 +496,19 @@ class Ldk: NSObject {
         currentBlockchainTipHash = blockHash
         currentBlockchainHeight = blockHeight
         addForegroundObserver()
+        
+        //TODO temp update to make sure file that wasn't being backuped up now is at least once. Can be removed in a few updates.
+        //*******************************
+        Task {
+            if let channelsOpenedWithCustomKeysManagerFile = Ldk.accountStoragePath?.appendingPathComponent(LdkFileNames.channelsOpenedWithCustomKeysManager.rawValue) {
+                if FileManager.default.fileExists(atPath: channelsOpenedWithCustomKeysManagerFile.path) {
+                    if let data = try? Data(contentsOf: URL(fileURLWithPath: channelsOpenedWithCustomKeysManagerFile.path), options: .mappedIfSafe) {
+                        BackupClient.addToPersistQueue(.misc(fileName: LdkFileNames.channelsOpenedWithCustomKeysManager.rawValue), [UInt8](data))
+                    }
+                }
+            }
+        }
+        //*******************************
            
         return handleResolve(resolve, .channel_manager_init_success)
     }

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@synonymdev/react-native-ldk",
   "title": "React Native LDK",
-  "version": "0.0.127",
+  "version": "0.0.128",
   "description": "React Native wrapper for LDK",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
- Sent/claimed payments files now being backed up
- `channel_opened_with_custom_keys_manager.json` file now being backed up
- Fix for android where above file was named incorrectly. It's now renamed and then backed up. (fix can be removed after a few releases)
- iOS trigger backup of above file. (fix can be removed after a few releases)
- Fixes a bug where misc files were not being restored with the correct extension.