### PR TITLE
feat: add bolt11 invoice string to sent stored payments

### DIFF
--- a/backup-server/package-lock.json
+++ b/backup-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "backup-server",
-  "version": "0.0.129",
+  "version": "0.0.130",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "backup-server",
-      "version": "0.0.129",
+      "version": "0.0.130",
       "license": "ISC",
       "dependencies": {
         "@tweedegolf/storage-abstraction": "^1.4.6",

--- a/backup-server/package.json
+++ b/backup-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backup-server",
-  "version": "0.0.129",
+  "version": "0.0.130",
   "description": "",
   "main": "index.js",
   "engines": {

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -375,7 +375,7 @@ PODS:
   - React-jsinspector (0.72.4)
   - React-logger (0.72.4):
     - glog
-  - react-native-ldk (0.0.128):
+  - react-native-ldk (0.0.130):
     - React
   - react-native-randombytes (3.6.1):
     - React-Core
@@ -723,7 +723,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: c7f826e40fa9cab5d37cab6130b1af237332b594
   React-jsinspector: aaed4cf551c4a1c98092436518c2d267b13a673f
   React-logger: da1ebe05ae06eb6db4b162202faeafac4b435e77
-  react-native-ldk: 7e754f4168e774326eaf2f0707843f5ce06f70bb
+  react-native-ldk: 70917f83fc99eab2fbd6df0edbd7ebd217bad7ea
   react-native-randombytes: 421f1c7d48c0af8dbcd471b0324393ebf8fe7846
   react-native-tcp-socket: c1b7297619616b4c9caae6889bcb0aba78086989
   React-NativeModulesApple: edb5ace14f73f4969df6e7b1f3e41bef0012740f

--- a/lib/android/src/main/java/com/reactnativeldk/LdkModule.kt
+++ b/lib/android/src/main/java/com/reactnativeldk/LdkModule.kt
@@ -792,6 +792,7 @@ class LdkModule(reactContext: ReactApplicationContext) : ReactContextBaseJavaMod
             UtilMethods.pay_invoice(invoice, Retry.timeout(timeoutSeconds.toLong()), channelManager)
         if (res.is_ok) {
             channelManagerPersister.persistPaymentSent(hashMapOf(
+                "bolt11_invoice" to paymentRequest,
                 "payment_id" to (res as Result_ThirtyTwoBytesPaymentErrorZ.Result_ThirtyTwoBytesPaymentErrorZ_OK).res.hexEncodedString(),
                 "payment_hash" to invoice.payment_hash().hexEncodedString(),
                 "amount_sat" to if (isZeroValueInvoice) amountSats.toLong() else ((invoice.amount_milli_satoshis() as Option_u64Z.Some).some.toInt() / 1000),
@@ -859,7 +860,7 @@ class LdkModule(reactContext: ReactApplicationContext) : ReactContextBaseJavaMod
             description,
             expiryDelta.toInt(),
             Option_u16Z.none()
-        );
+        )
 
         if (res.is_ok) {
             return promise.resolve((res as Result_Bolt11InvoiceSignOrCreationErrorZ_OK).res.asJson)

--- a/lib/android/src/main/java/com/reactnativeldk/classes/LdkChannelManagerPersister.kt
+++ b/lib/android/src/main/java/com/reactnativeldk/classes/LdkChannelManagerPersister.kt
@@ -74,7 +74,7 @@ class LdkChannelManagerPersister: ChannelManagerConstructor.EventHandler {
             body.putHexString("payment_hash", (paymentPathSuccessful.payment_hash as Option_ThirtyTwoBytesZ.Some).some)
 
             val pathHops = Arguments.createArray()
-            println(paymentPathSuccessful.path)
+            event.path._hops.forEach { pathHops.pushMap(it.asJson) }
             body.putArray("path_hops", pathHops)
 
             return LdkEventEmitter.send(EventTypes.channel_manager_payment_path_successful, body)

--- a/lib/ios/Ldk.swift
+++ b/lib/ios/Ldk.swift
@@ -866,6 +866,7 @@ class Ldk: NSObject {
         
         if res.isOk() {
             channelManagerPersister.persistPaymentSent([
+                "bolt11_invoice": String(paymentRequest),
                 "payment_id": Data(res.getValue() ?? []).hexEncodedString(),
                 "payment_hash": Data(invoice.paymentHash() ?? []).hexEncodedString(),
                 "amount_sat": isZeroValueInvoice ? amountSats : (invoice.amountMilliSatoshis() ?? 0) / 1000,

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@synonymdev/react-native-ldk",
   "title": "React Native LDK",
-  "version": "0.0.129",
+  "version": "0.0.130",
   "description": "React Native wrapper for LDK",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/lib/src/utils/types.ts
+++ b/lib/src/utils/types.ts
@@ -68,6 +68,7 @@ export type TChannelManagerClaim = {
 };
 
 export type TChannelManagerPaymentSent = {
+	bolt11_invoice?: string;
 	payment_id: string;
 	payment_preimage?: string;
 	payment_hash: string;


### PR DESCRIPTION
Resolves #156 

- Saves invoice string when paying for a `bolt11` invoice to **sent** payments file

On Android also:
- Returns route hops info in case of `PaymentPathSuccessful` event (already exists in iOS)

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206525067124277