### PR TITLE
use logger from ldkdevkit

### DIFF
--- a/lib/ios/Classes/LdkLogger.swift
+++ b/lib/ios/Classes/LdkLogger.swift
@@ -27,7 +27,7 @@ fileprivate func levelString(_ level: Level) -> String {
     }
 }
 
-class LdkLogger: Logger {
+class LdkLogger: LightningDevKit.Bindings.Logger {
     var activeLevels: [String: Bool] = [:]
     
     override func log(record: Record) {


### PR DESCRIPTION
Hi, after trying multiple times to make this app to build using EAS Build from expo, it always seems to fail at this step, but changing this line makes it work, am I missing something here or it really should be imported from LDKdevkit

This is the error that it returns

![image](https://github.com/synonymdev/react-native-ldk/assets/12129203/26226f4d-6085-45ca-bf9d-2e0ee4c5f747)