### PR TITLE
feat: Persist invoice payment description

### DIFF
--- a/lib/android/src/main/java/com/reactnativeldk/LdkModule.kt
+++ b/lib/android/src/main/java/com/reactnativeldk/LdkModule.kt
@@ -231,7 +231,7 @@ class LdkModule(reactContext: ReactApplicationContext) : ReactContextBaseJavaMod
 
     @ReactMethod
     fun initKeysManager(seed: String, destinationScriptPublicKey: String, witnessProgram: String, witnessProgramVersion: Double, promise: Promise) {
-        if (keysManager !== null) {
+        if (keysManager != null) {
             return handleResolve(promise, LdkCallbackResponses.keys_manager_init_success)
         }
 
@@ -303,7 +303,7 @@ class LdkModule(reactContext: ReactApplicationContext) : ReactContextBaseJavaMod
 
     @ReactMethod
     fun initNetworkGraph(network: String, rapidGossipSyncUrl: String, skipHoursThreshold: Double, promise: Promise) {
-        if (networkGraph !== null) {
+        if (networkGraph != null) {
             return handleReject(promise, LdkErrors.already_init)
         }
 
@@ -315,7 +315,7 @@ class LdkModule(reactContext: ReactApplicationContext) : ReactContextBaseJavaMod
         }
 
         if (networkGraph == null) {
-            val ldkNetwork = getNetwork(network);
+            val ldkNetwork = getNetwork(network)
             networkGraph = NetworkGraph.of(ldkNetwork.first, logger.logger)
 
             LdkEventEmitter.send(EventTypes.native_log, "Failed to load cached network graph from disk. Will sync from scratch.")
@@ -401,7 +401,7 @@ class LdkModule(reactContext: ReactApplicationContext) : ReactContextBaseJavaMod
         ldkCurrency = getNetwork(network).second
 
         val enableP2PGossip = rapidGossipSync == null
-        
+
         var channelManagerSerialized: ByteArray? = null
         val channelManagerFile = File(accountStoragePath + "/" + LdkFileNames.ChannelManager.fileName)
         if (channelManagerFile.exists()) {
@@ -414,7 +414,7 @@ class LdkModule(reactContext: ReactApplicationContext) : ReactContextBaseJavaMod
             networkGraph!!,
             logger.logger
         ) ?: return handleReject(promise, LdkErrors.init_scorer_failed)
-        
+
         val scorer = MultiThreadedLockableScore.of(probabilisticScorer.as_Score())
 
         val scoringParams = ProbabilisticScoringDecayParameters.with_default()
@@ -777,6 +777,7 @@ class LdkModule(reactContext: ReactApplicationContext) : ReactContextBaseJavaMod
         if (res.is_ok) {
             channelManagerPersister.persistPaymentSent(hashMapOf(
                 "bolt11_invoice" to paymentRequest,
+                "description" to (invoice.into_signed_raw().raw_invoice().description()?.into_inner() ?: ""),
                 "payment_id" to (res as Result_ThirtyTwoBytesPaymentErrorZ.Result_ThirtyTwoBytesPaymentErrorZ_OK).res.hexEncodedString(),
                 "payment_hash" to invoice.payment_hash().hexEncodedString(),
                 "amount_sat" to if (isZeroValueInvoice) amountSats.toLong() else ((invoice.amount_milli_satoshis() as Option_u64Z.Some).some.toInt() / 1000),
@@ -927,7 +928,7 @@ class LdkModule(reactContext: ReactApplicationContext) : ReactContextBaseJavaMod
         if (channelStoragePath == "") {
             return handleReject(promise, LdkErrors.init_storage_path)
         }
-        
+
         val list = Arguments.createArray()
         Files.walk(Paths.get(channelStoragePath))
             .filter { Files.isRegularFile(it) }

--- a/lib/ios/Ldk.swift
+++ b/lib/ios/Ldk.swift
@@ -855,6 +855,7 @@ class Ldk: NSObject {
         if res.isOk() {
             channelManagerPersister.persistPaymentSent([
                 "bolt11_invoice": String(paymentRequest),
+                "description": invoice.intoSignedRaw().rawInvoice().description()?.intoInner() ?? "",
                 "payment_id": Data(res.getValue() ?? []).hexEncodedString(),
                 "payment_hash": Data(invoice.paymentHash() ?? []).hexEncodedString(),
                 "amount_sat": isZeroValueInvoice ? amountSats : (invoice.amountMilliSatoshis() ?? 0) / 1000,

--- a/lib/src/utils/types.ts
+++ b/lib/src/utils/types.ts
@@ -69,6 +69,7 @@ export type TChannelManagerClaim = {
 
 export type TChannelManagerPaymentSent = {
 	bolt11_invoice?: string;
+	description?: string;
 	payment_id: string;
 	payment_preimage?: string;
 	payment_hash: string;


### PR DESCRIPTION
Resolves #220 

Add the invoice description to sent payments persistence, to have it readily available and remove the need of an additional `decode` call from the RN code.

See this `todo` line for more info on the reason:
https://github.com/synonymdev/bitkit/pull/1592/files#diff-d692e78fc8af95524590b3741723f8e0157016777629bdd768fc753b83daa30fR339

Tested with:
1. LND create invoice with description
   ```
   lncli addinvoice --amt 2 --memo "test description 2"
   ```
   Copy `payment_request`
2. Example app: `Pay Invoice` (should paste from clipboard)
3. Example app: `Get sent payments` : should print description ✅ 

| <img width="315" src="https://github.com/synonymdev/react-native-ldk/assets/4588074/1796bf84-27ce-4272-a578-fb88a65993ab"> |
| - |

### TODO
- [x] Test Android
- [x] Test iOS