### PR TITLE
Fix watchOutputs Loop

### DIFF
--- a/backup-server/src/server.js
+++ b/backup-server/src/server.js
@@ -28,7 +28,8 @@ const ldkLabels = [
     'payments_claimed',
     'payments_sent',
     'bolt11_invoices',
-    'channel_opened_with_custom_keys_manager'
+    'channel_opened_with_custom_keys_manager',
+    'confirmed_watch_outputs',
 ];
 const bitkitLabels = [
     'bitkit_settings',

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -375,7 +375,7 @@ PODS:
   - React-jsinspector (0.72.4)
   - React-logger (0.72.4):
     - glog
-  - react-native-ldk (0.0.132):
+  - react-native-ldk (0.0.134):
     - React
   - react-native-randombytes (3.6.1):
     - React-Core
@@ -723,7 +723,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: c7f826e40fa9cab5d37cab6130b1af237332b594
   React-jsinspector: aaed4cf551c4a1c98092436518c2d267b13a673f
   React-logger: da1ebe05ae06eb6db4b162202faeafac4b435e77
-  react-native-ldk: 4bb809be74082223644931a3239323af56c7ee8f
+  react-native-ldk: e4971770e3773415fff4e5aa04df83f9d5485744
   react-native-randombytes: 421f1c7d48c0af8dbcd471b0324393ebf8fe7846
   react-native-tcp-socket: c1b7297619616b4c9caae6889bcb0aba78086989
   React-NativeModulesApple: edb5ace14f73f4969df6e7b1f3e41bef0012740f

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@synonymdev/react-native-ldk",
   "title": "React Native LDK",
-  "version": "0.0.132",
+  "version": "0.0.134",
   "description": "React Native wrapper for LDK",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/lib/src/utils/types.ts
+++ b/lib/src/utils/types.ts
@@ -478,6 +478,7 @@ export enum ELdkFiles {
 	payments_claimed = 'payments_claimed.json', // Written in swift/kotlin and read from JS
 	payments_sent = 'payments_sent.json', // Written in swift/kotlin and read from JS
 	bolt11_invoices = 'bolt11_invoices.json', // Saved/read from JS
+	confirmed_watch_outputs = 'confirmed_watch_outputs.json',
 }
 
 export enum ELdkData {


### PR DESCRIPTION
This PR:
- Adds and tracks `confirmedWatchOutputs` in `lightning-manager.ts`.
- Increases timeout to `20000`ms.
- Updates `retrySyncOrReturnError` to return immediately if a `time-out` is detected.
- Replaces map with for of loop for Electrum queries.
- Adds `saveConfirmedWatchOutput` & `getConfirmedWatchOutputs` methods.
- Bumps version to `0.0.134`.
- Addresses #221 