### PR TITLE
Retry spending outputs after force close

### DIFF
--- a/lib/ios/Ldk.m
+++ b/lib/ios/Ldk.m
@@ -167,6 +167,11 @@ RCT_EXTERN_METHOD(reconstructAndSpendOutputs:(NSString *)outputScriptPubKey
                   changeDestinationScript:(NSString *)changeDestinationScript
                   resolve:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject)
+RCT_EXTERN_METHOD(spendRecoveredForceCloseOutputs:(NSString *)transaction
+                  confirmationHeight:(NSInteger *)confirmationHeight
+                  changeDestinationScript:(NSString *)changeDestinationScript
+                  resolve:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject)
 RCT_EXTERN_METHOD(nodeSign:(NSString *)message
                   resolve:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject)

--- a/lib/src/ldk.ts
+++ b/lib/src/ldk.ts
@@ -37,6 +37,7 @@ import {
 	TBackedUpFileList,
 	TDownloadScorer,
 	TInitKeysManager,
+	TSpendRecoveredForceCloseOutputsReq,
 } from './utils/types';
 import { extractPaymentRequest } from './utils/helpers';
 
@@ -1205,6 +1206,25 @@ class LDK {
 			return ok(res);
 		} catch (e) {
 			this.writeErrorToLog('reconstructAndSpendOutputs', e);
+			return err(e);
+		}
+	}
+
+	async spendRecoveredForceCloseOutputs({
+		transaction,
+		confirmationHeight,
+		changeDestinationScript,
+	}: TSpendRecoveredForceCloseOutputsReq): Promise<Result<string[]>> {
+		try {
+			const res = await NativeLDK.spendRecoveredForceCloseOutputs(
+				transaction,
+				confirmationHeight,
+				changeDestinationScript,
+			);
+			this.writeDebugToLog('spendRecoveredForceCloseOutputs', res);
+			return ok(res);
+		} catch (e) {
+			this.writeErrorToLog('spendRecoveredForceCloseOutputs', e);
 			return err(e);
 		}
 	}

--- a/lib/src/utils/types.ts
+++ b/lib/src/utils/types.ts
@@ -592,6 +592,12 @@ export type TReconstructAndSpendOutputsReq = {
 	changeDestinationScript: string;
 };
 
+export type TSpendRecoveredForceCloseOutputsReq = {
+	transaction: string;
+	confirmationHeight: number;
+	changeDestinationScript: string;
+};
+
 export type TBackupServerDetails = {
 	host: string;
 	serverPubKey: string;


### PR DESCRIPTION
Helper function for getting any spendable outputs from force closed channels and trying to spend them again in the event they were not spent automatically.