### PR TITLE
feat: list all channel monitors

### DIFF
--- a/example/Dev.tsx
+++ b/example/Dev.tsx
@@ -588,6 +588,23 @@ const Dev = (): ReactElement => {
 					/>
 
 					<Button
+						title={'List channel monitors'}
+						onPress={async (): Promise<void> => {
+							const monitorsRes = await ldk.listChannelMonitors(true);
+							if (monitorsRes.isErr()) {
+								return setMessage(monitorsRes.error.message);
+							}
+
+							let msg = `Channel Monitors (${monitorsRes.value.length}): \n`;
+							monitorsRes.value.forEach((monitor) => {
+								msg += `\n\n${JSON.stringify(monitor)}`;
+							});
+
+							setMessage(msg);
+						}}
+					/>
+
+					<Button
 						title={'Show version'}
 						onPress={async (): Promise<void> => {
 							const ldkVersion = await ldk.version();

--- a/lib/android/src/main/java/com/reactnativeldk/Helpers.kt
+++ b/lib/android/src/main/java/com/reactnativeldk/Helpers.kt
@@ -199,6 +199,21 @@ val RouteHop.asJson: WritableMap
         return hop
     }
 
+
+fun ChannelMonitor.asJson(channelId: String): WritableMap {
+    val result = Arguments.createMap()
+    result.putString("channel_id", channelId)
+    result.putHexString("funding_txo", _funding_txo._b)
+    result.putHexString("counterparty_node_id", _counterparty_node_id)
+
+    val balances = Arguments.createArray()
+    _claimable_balances.iterator().forEach { balance ->
+        balances.pushMap(balance.asJson)
+    }
+    result.putArray("claimable_balances", balances)
+    return result
+}
+
 fun WritableMap.putHexString(key: String, bytes: ByteArray?) {
     if (bytes != null) {
         putString(key, bytes.hexEncodedString())
@@ -437,55 +452,59 @@ fun UserConfig.mergeWithMap(map: ReadableMap): UserConfig {
     return this
 }
 
-fun ChainMonitor.getClaimableBalancesAsJson(ignoredChannels: Array<ChannelDetails>): WritableArray {
-    val result = Arguments.createArray()
-
-    get_claimable_balances(ignoredChannels).iterator().forEach { balance ->
+val Balance.asJson: WritableMap
+    get() {
         val map = Arguments.createMap()
         //Defaults if all castings for balance fail
         map.putInt("amount_satoshis", 0)
         map.putString("type", "Unknown")
 
-        (balance as? Balance.ClaimableAwaitingConfirmations)?.let { claimableAwaitingConfirmations ->
+        (this as? Balance.ClaimableAwaitingConfirmations)?.let { claimableAwaitingConfirmations ->
             map.putInt("amount_satoshis", claimableAwaitingConfirmations.amount_satoshis.toInt())
             map.putInt("confirmation_height", claimableAwaitingConfirmations.confirmation_height)
             map.putString("type", "ClaimableAwaitingConfirmations")
         }
 
-        (balance as? Balance.ClaimableOnChannelClose)?.let { claimableOnChannelClose ->
+        (this as? Balance.ClaimableOnChannelClose)?.let { claimableOnChannelClose ->
             map.putInt("amount_satoshis", claimableOnChannelClose.amount_satoshis.toInt())
             map.putString("type", "ClaimableOnChannelClose")
         }
 
-        (balance as? Balance.ContentiousClaimable)?.let { contentiousClaimable ->
+        (this as? Balance.ContentiousClaimable)?.let { contentiousClaimable ->
             map.putInt("amount_satoshis", contentiousClaimable.amount_satoshis.toInt())
             map.putInt("timeout_height", contentiousClaimable.timeout_height)
             map.putString("type", "ContentiousClaimable")
         }
 
-        (balance as? Balance.CounterpartyRevokedOutputClaimable)?.let { counterpartyRevokedOutputClaimable ->
+        (this as? Balance.CounterpartyRevokedOutputClaimable)?.let { counterpartyRevokedOutputClaimable ->
             map.putInt("amount_satoshis", counterpartyRevokedOutputClaimable.amount_satoshis.toInt())
             map.putString("type", "CounterpartyRevokedOutputClaimable")
         }
 
-        (balance as? Balance.MaybePreimageClaimableHTLC)?.let { maybePreimageClaimableHTLC ->
+        (this as? Balance.MaybePreimageClaimableHTLC)?.let { maybePreimageClaimableHTLC ->
             map.putInt("amount_satoshis", maybePreimageClaimableHTLC.amount_satoshis.toInt())
             map.putInt("expiry_height", maybePreimageClaimableHTLC.expiry_height)
             map.putString("type", "MaybePreimageClaimableHTLC")
         }
 
-        (balance as? Balance.MaybeTimeoutClaimableHTLC)?.let { maybeTimeoutClaimableHTLC ->
+        (this as? Balance.MaybeTimeoutClaimableHTLC)?.let { maybeTimeoutClaimableHTLC ->
             map.putInt("amount_satoshis", maybeTimeoutClaimableHTLC.amount_satoshis.toInt())
             map.putInt("claimable_height", maybeTimeoutClaimableHTLC.claimable_height)
             map.putString("type", "MaybeTimeoutClaimableHTLC")
         }
 
-        result.pushMap(map)
+        return map
+    }
+
+fun ChainMonitor.getClaimableBalancesAsJson(ignoredChannels: Array<ChannelDetails>): WritableArray {
+    val result = Arguments.createArray()
+
+    get_claimable_balances(ignoredChannels).iterator().forEach { balance ->
+        result.pushMap(balance.asJson)
     }
 
     return result
 }
-
 
 /// Helper for returning real network and currency as a tuple from a string
 fun getNetwork(chain: String): Pair<Network, Currency> {

--- a/lib/ios/Ldk.m
+++ b/lib/ios/Ldk.m
@@ -109,6 +109,9 @@ RCT_EXTERN_METHOD(listUsableChannels:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject)
 RCT_EXTERN_METHOD(listChannelFiles:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject)
+RCT_EXTERN_METHOD(listChannelMonitors:(BOOL *)ignoreOpenChannels
+                  resolve:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject)
 RCT_EXTERN_METHOD(networkGraphListNodeIds:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject)
 RCT_EXTERN_METHOD(networkGraphListChannels:(RCTPromiseResolveBlock)resolve

--- a/lib/ios/Ldk.swift
+++ b/lib/ios/Ldk.swift
@@ -1015,6 +1015,49 @@ class Ldk: NSObject {
     }
     
     @objc
+    func listChannelMonitors(_ ignoreOpenChannels: Bool, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+        guard let channelManager else {
+            return handleReject(reject, .init_channel_manager)
+        }
+        
+        guard let keysManager else {
+            return handleReject(reject, .init_keys_manager)
+        }
+        
+        guard let channelStoragePath = Ldk.channelStoragePath else {
+            return handleReject(reject, .init_storage_path)
+        }
+        
+        let excludeChannelIds = ignoreOpenChannels ? channelManager.listChannels().map { Data($0.getChannelId() ?? []).hexEncodedString() }.filter { $0 != "" } : []
+
+        let channelFiles = try! FileManager.default.contentsOfDirectory(at: channelStoragePath, includingPropertiesForKeys: nil)
+        
+        var result: [[String: Any?]] = []
+        for channelFile in channelFiles {
+            let channelId = channelFile.lastPathComponent.replacingOccurrences(of: ".bin", with: "")
+            
+            guard !excludeChannelIds.contains(channelId) else {
+                continue
+            }
+            
+            let channelMonitorResult = Bindings.readThirtyTwoBytesChannelMonitor(
+                ser: [UInt8](try! Data(contentsOf: channelFile.standardizedFileURL)),
+                argA: keysManager.inner.asEntropySource(),
+                argB: keysManager.signerProvider
+            )
+            
+            guard let (channelId, channelMonitor) = channelMonitorResult.getValue() else {
+                LdkEventEmitter.shared.send(withEvent: .native_log, body: "Loading channel error. No channel value.")
+                continue
+            }
+            
+            result.append(channelMonitor.asJson(channelId: Data(channelId).hexEncodedString()))
+        }
+        
+        return resolve(result)
+    }
+    
+    @objc
     func networkGraphListNodeIds(_ resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
         guard let networkGraph = networkGraph?.readOnly() else {
             return handleReject(reject, .init_network_graph)
@@ -1203,7 +1246,7 @@ class Ldk: NSObject {
     
     @objc
     func spendRecoveredForceCloseOutputs(_ transaction: NSString, confirmationHeight: NSInteger, changeDestinationScript: NSString, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
-        //TODO check which ones are not open channels and try spend them again
+        
         guard let channelStoragePath = Ldk.channelStoragePath, let keysManager, let channelManager else {
             return handleReject(reject, .init_storage_path)
         }

--- a/lib/src/ldk.ts
+++ b/lib/src/ldk.ts
@@ -38,6 +38,7 @@ import {
 	TDownloadScorer,
 	TInitKeysManager,
 	TSpendRecoveredForceCloseOutputsReq,
+	TChannelMonitor,
 } from './utils/types';
 import { extractPaymentRequest } from './utils/helpers';
 
@@ -953,6 +954,24 @@ class LDK {
 			return ok(res);
 		} catch (e) {
 			this.writeErrorToLog('listChannelFiles', e);
+			return err(e);
+		}
+	}
+
+	/**
+	 * Lists all channel monitors from storage
+	 * @param ignoreOpenChannels
+	 * @returns {Promise<Ok<Ok<string[]> | Err<string[]>> | Err<unknown>>}
+	 */
+	async listChannelMonitors(
+		ignoreOpenChannels: boolean,
+	): Promise<Result<TChannelMonitor[]>> {
+		try {
+			const res = await NativeLDK.listChannelMonitors(ignoreOpenChannels);
+			this.writeDebugToLog('listChannelMonitors', `Monitors: ${res.length}`);
+			return ok(res);
+		} catch (e) {
+			this.writeErrorToLog('listChannelMonitors', e);
 			return err(e);
 		}
 	}

--- a/lib/src/utils/types.ts
+++ b/lib/src/utils/types.ts
@@ -164,6 +164,13 @@ export type TChannel = {
 	confirmations: number;
 };
 
+export type TChannelMonitor = {
+	channel_id: string;
+	funding_txo: string;
+	counterparty_node_id: string;
+	claimable_balances: [TClaimableBalance];
+};
+
 export type TNetworkGraphChannelInfo = {
 	shortChannelId: string;
 	capacity_sats?: number;


### PR DESCRIPTION
Lists all or just closed channel monitors. Can be used to read which claimable balances are coming from which channels.