### PR TITLE
Broadcasted transactions cleanup

### DIFF
--- a/lib/android/src/main/java/com/reactnativeldk/LdkModule.kt
+++ b/lib/android/src/main/java/com/reactnativeldk/LdkModule.kt
@@ -1244,7 +1244,7 @@ class LdkModule(reactContext: ReactApplicationContext) : ReactContextBaseJavaMod
             logDump.add("Open channel:")
 
             channel._funding_txo?._txid?.let { txId ->
-                logDump.add("Funding txid: ${txId.hexEncodedString()}")
+                logDump.add("Funding txid: ${txId.reversedArray().hexEncodedString()}")
             }
 
             logDump.add("Ready: ${if (channel._is_channel_ready) "YES" else "NO"}")

--- a/lib/ios/Helpers.swift
+++ b/lib/ios/Helpers.swift
@@ -127,7 +127,7 @@ extension ChannelDetails {
             "confirmations_required": getConfirmationsRequired() as Any, // Optional number
             "short_channel_id": shortChannelId,
             "inbound_scid_alias": getInboundScidAlias() != nil ? String(getInboundScidAlias()!) : shortChannelId, //String
-            "inbound_payment_scid": getInboundPaymentScid() as Any, //Optional number,
+            "inbound_payment_scid": getInboundPaymentScid() != nil ? String(getInboundPaymentScid()!) : "", //String,
             "inbound_capacity_sat": getInboundCapacityMsat() / 1000,
             "outbound_capacity_sat": getOutboundCapacityMsat() / 1000,
             "channel_value_satoshis": getChannelValueSatoshis(),

--- a/lib/src/utils/helpers.ts
+++ b/lib/src/utils/helpers.ts
@@ -301,6 +301,11 @@ export const findOutputsFromRawTxs = (
 	return result;
 };
 
+export const getTxIdFromRawTx = (rawTx: string): string => {
+	const tx = bitcoin.Transaction.fromHex(rawTx);
+	return tx.getId();
+};
+
 /**
  * Pauses execution of a function.
  * @param {number} ms The time to wait in milliseconds.

--- a/lib/src/utils/types.ts
+++ b/lib/src/utils/types.ts
@@ -481,6 +481,7 @@ export enum ELdkFiles {
 	peers = 'peers.json', //File saved from JS
 	unconfirmed_transactions = 'unconfirmed_transactions.json',
 	broadcasted_transactions = 'broadcasted_transactions.json',
+	confirmed_broadcasted_transactions = 'confirmed_broadcasted_transactions.json',
 	payment_ids = 'payment_ids.json',
 	spendable_outputs = 'spendable_outputs.json',
 	payments_claimed = 'payments_claimed.json', // Written in swift/kotlin and read from JS


### PR DESCRIPTION
- On startup (without holding up the startup function) iterate through all the stored broadcasted txs and remove any txs confirmed with 6+ blocks so we don't waste time rebroadcasting confirmed txs.
- Confirmed broadcasted txs are saved in a separate file as a backup.
- Fix iOS type for `inbound_payment_scid`
- Reverse txid for node state dump on Android
