### PR TITLE
feat: append channel monitor details to lsp log

### DIFF
--- a/lib/src/lightning-manager.ts
+++ b/lib/src/lightning-manager.ts
@@ -1989,10 +1989,6 @@ class LightningManager {
 			(p) => p.payment_hash === res.payment_hash,
 		);
 
-		console.error(
-			`Existing claimed payments: ${JSON.stringify(existingClaimedPayment)}`,
-		);
-
 		if (
 			existingClaimedPayment &&
 			existingClaimedPayment.state === 'successful'

--- a/lib/src/lightning-manager.ts
+++ b/lib/src/lightning-manager.ts
@@ -57,6 +57,7 @@ import {
 	IAddress,
 	TLspLogPayload,
 	TLspLogEvent,
+	TChannelMonitor,
 } from './utils/types';
 import {
 	appendPath,
@@ -2248,14 +2249,23 @@ class LightningManager {
 		await this.syncLdk();
 	}
 
-	private async onLspLogEvent(payload: any): Promise<void> {
+	private async onLspLogEvent(payload: object): Promise<void> {
 		if (!this.lspLogEvent) {
 			return;
 		}
+		let body: { channelClose: object; channelFiles: TChannelMonitor[] } = {
+			channelClose: payload,
+			channelFiles: [],
+		};
 		const nodeIdRes = await ldk.nodeId();
 
+		const channelFiles = await ldk.listChannelMonitors(true);
+		if (channelFiles.isOk()) {
+			body.channelFiles = channelFiles.value;
+		}
+
 		await this.lspLogEvent({
-			body: JSON.stringify(payload),
+			body: JSON.stringify(body),
 			nodeId: nodeIdRes.isOk() ? nodeIdRes.value : '',
 		});
 	}


### PR DESCRIPTION
Appends all closed channel monitor details to LSP log event body

```
{
    "channelClose": {
        "commitment_tx_fee": 2,
        "pending_htlcs_count": 1,
        "commitment_tx": "Data(channelClose.getCommitmentTx()).hexEncodedString()"
    },
    "channelFiles": [
        {
            "channel_id": "731a159d8829c8a233e421340dbe89985f19668098b82a0c58560aa8321de38c",
            "counterparty_node_id": "0341e41583ad691951634e24dd20252d13feace9286a85d47f220dde74e7e09a15",
            "funding_txo_index": 0,
            "funding_txo_txid": "8ce31d32a80a56580c2ab8988066195f9889be0d3421e433a2c829889d151a73",
            "claimable_balances": [
                {
                    "amount_satoshis": 50000,
                    "type": "ClaimableAwaitingConfirmations",
                    "confirmation_height": 6759
                }
            ]
        }
    ]
}
```