### PR TITLE
Upgrades raw-transaction-decoder to 1.1.0

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -316,7 +316,7 @@ PODS:
   - React-jsinspector (0.72.4)
   - React-logger (0.72.4):
     - glog
-  - react-native-ldk (0.0.140):
+  - react-native-ldk (0.0.141):
     - React
   - react-native-randombytes (3.6.1):
     - React-Core
@@ -621,7 +621,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: c7f826e40fa9cab5d37cab6130b1af237332b594
   React-jsinspector: aaed4cf551c4a1c98092436518c2d267b13a673f
   React-logger: da1ebe05ae06eb6db4b162202faeafac4b435e77
-  react-native-ldk: c5037d5c182a25d23569ae79083bb18c8bc0a69a
+  react-native-ldk: 58b28973bedc64333c350b9074554f814ba3daec
   react-native-randombytes: 421f1c7d48c0af8dbcd471b0324393ebf8fe7846
   react-native-tcp-socket: c1b7297619616b4c9caae6889bcb0aba78086989
   React-NativeModulesApple: edb5ace14f73f4969df6e7b1f3e41bef0012740f

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -2413,17 +2413,17 @@
   dependencies:
     "@sinonjs/commons" "^3.0.0"
 
-"@synonymdev/raw-transaction-decoder@1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@synonymdev/raw-transaction-decoder/-/raw-transaction-decoder-1.0.0.tgz#2090dd0979c0f35f126f9a2c7557a4bc8cda44eb"
-  integrity sha512-YCv96YA+OTFbb/3pUFEXavaivP1Ofwq7TJInsHlP7QrJlBBSqnT3aZXsRGC2dLm8PA8HR4Fnu5Kq0tCnJ7tEqA==
+"@synonymdev/raw-transaction-decoder@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@synonymdev/raw-transaction-decoder/-/raw-transaction-decoder-1.1.0.tgz#9777fd4e3b696974594338ad7271aa4fe2133d8a"
+  integrity sha512-X9v/HZ7b0MUKcvEOMtuqNRB7bzWzK/GkLeh/BsqPIDnjS3yoRF4jHiIGhW2WQunBR1PUPXo5qB8LoFFGqCpUoA==
   dependencies:
     bitcoinjs-lib "6.1.4"
 
 "@synonymdev/react-native-ldk@../lib":
-  version "0.0.140"
+  version "0.0.141"
   dependencies:
-    "@synonymdev/raw-transaction-decoder" "1.0.0"
+    "@synonymdev/raw-transaction-decoder" "1.1.0"
     bech32 "^2.0.0"
     bitcoinjs-lib "^6.0.2"
 

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@synonymdev/react-native-ldk",
   "title": "React Native LDK",
-  "version": "0.0.140",
+  "version": "0.0.141",
   "description": "React Native wrapper for LDK",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -65,7 +65,7 @@
     "typescript": "^4.2.4"
   },
   "dependencies": {
-    "@synonymdev/raw-transaction-decoder": "1.0.0",
+    "@synonymdev/raw-transaction-decoder": "1.1.0",
     "bech32": "^2.0.0",
     "bitcoinjs-lib": "^6.0.2"
   },

--- a/lib/yarn.lock
+++ b/lib/yarn.lock
@@ -268,10 +268,10 @@
   resolved "https://registry.yarnpkg.com/@react-native-community/eslint-plugin/-/eslint-plugin-1.2.0.tgz#7d6d789ae8edf73dc9bed1246cd48277edea8066"
   integrity sha512-o6aam+0Ug1xGK3ABYmBm0B1YuEKfM/5kaoZO0eHbZwSpw9UzDX4G5y4Nx/K20FHqUmJHkZmLvOUFYwN4N+HqKA==
 
-"@synonymdev/raw-transaction-decoder@1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@synonymdev/raw-transaction-decoder/-/raw-transaction-decoder-1.0.0.tgz#2090dd0979c0f35f126f9a2c7557a4bc8cda44eb"
-  integrity sha512-YCv96YA+OTFbb/3pUFEXavaivP1Ofwq7TJInsHlP7QrJlBBSqnT3aZXsRGC2dLm8PA8HR4Fnu5Kq0tCnJ7tEqA==
+"@synonymdev/raw-transaction-decoder@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@synonymdev/raw-transaction-decoder/-/raw-transaction-decoder-1.1.0.tgz#9777fd4e3b696974594338ad7271aa4fe2133d8a"
+  integrity sha512-X9v/HZ7b0MUKcvEOMtuqNRB7bzWzK/GkLeh/BsqPIDnjS3yoRF4jHiIGhW2WQunBR1PUPXo5qB8LoFFGqCpUoA==
   dependencies:
     bitcoinjs-lib "6.1.4"
 


### PR DESCRIPTION
This PR:
- Upgrades `@synonymdev/raw-transaction-decoder` to `1.1.0` to include the following:
  - https://github.com/synonymdev/raw-transaction-decoder/pull/1