### PR TITLE
fix: increase android connect timeout to 3s

### DIFF
--- a/lib/package.json
+++ b/lib/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@synonymdev/react-native-ldk",
   "title": "React Native LDK",
-  "version": "0.0.141",
+  "version": "0.0.143",
   "description": "React Native wrapper for LDK",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
- Increases timeout when connecting dropped peers to 3 seconds
- Adds all peers whether initial connection was success or failure to the watch list