### PR TITLE
feat: ios restart debounce, dropped peer connection handler

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -316,7 +316,7 @@ PODS:
   - React-jsinspector (0.72.4)
   - React-logger (0.72.4):
     - glog
-  - react-native-ldk (0.0.141):
+  - react-native-ldk (0.0.143):
     - React
   - react-native-randombytes (3.6.1):
     - React-Core
@@ -621,7 +621,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: c7f826e40fa9cab5d37cab6130b1af237332b594
   React-jsinspector: aaed4cf551c4a1c98092436518c2d267b13a673f
   React-logger: da1ebe05ae06eb6db4b162202faeafac4b435e77
-  react-native-ldk: 58b28973bedc64333c350b9074554f814ba3daec
+  react-native-ldk: 12d78fe1141ad4343a2842340f7ebf8539dcc3b0
   react-native-randombytes: 421f1c7d48c0af8dbcd471b0324393ebf8fe7846
   react-native-tcp-socket: c1b7297619616b4c9caae6889bcb0aba78086989
   React-NativeModulesApple: edb5ace14f73f4969df6e7b1f3e41bef0012740f

--- a/lib/android/src/main/java/com/reactnativeldk/LdkModule.kt
+++ b/lib/android/src/main/java/com/reactnativeldk/LdkModule.kt
@@ -641,7 +641,7 @@ class LdkModule(reactContext: ReactApplicationContext) : ReactContextBaseJavaMod
                 peerHandler!!.connect(pubKey.hexa(), InetSocketAddress(address, port.toInt()), 3000)
                 LdkEventEmitter.send(EventTypes.native_log, "Connection to peer $pubKey re-established by handleDroppedPeers().")
             } catch (e: Exception) {
-                LdkEventEmitter.send(EventTypes.native_log, "Error connecting peer $pubKey. Error: $e")
+                LdkEventEmitter.send(EventTypes.native_log, "Error connecting peer from handleDroppedPeers() $pubKey. Error: $e")
             } finally {
                 currentlyConnectingPeers.remove(pubKey)
             }


### PR DESCRIPTION
- iOS only restart LDK if app was in background for +5 seconds. Prevents unintentionally restarts.
- iOS timer to watch for dropped peer connections.
- iOS check for preventing additional connections when a peer is already connecting or connecting.