### PR TITLE
fix: save addresses only when used for closing a channel

### DIFF
--- a/.github/workflows/e2e-android.yml
+++ b/.github/workflows/e2e-android.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   e2e-android:
-    runs-on: macos-12
+    runs-on: macos-13
     timeout-minutes: 120
 
     steps:

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -316,7 +316,7 @@ PODS:
   - React-jsinspector (0.72.4)
   - React-logger (0.72.4):
     - glog
-  - react-native-ldk (0.0.143):
+  - react-native-ldk (0.0.145):
     - React
   - react-native-randombytes (3.6.1):
     - React-Core
@@ -621,7 +621,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: c7f826e40fa9cab5d37cab6130b1af237332b594
   React-jsinspector: aaed4cf551c4a1c98092436518c2d267b13a673f
   React-logger: da1ebe05ae06eb6db4b162202faeafac4b435e77
-  react-native-ldk: 12d78fe1141ad4343a2842340f7ebf8539dcc3b0
+  react-native-ldk: 496216796eafbd77c43cd5228342460a242cf7ed
   react-native-randombytes: 421f1c7d48c0af8dbcd471b0324393ebf8fe7846
   react-native-tcp-socket: c1b7297619616b4c9caae6889bcb0aba78086989
   React-NativeModulesApple: edb5ace14f73f4969df6e7b1f3e41bef0012740f

--- a/example/ios/exmpl.xcodeproj/project.pbxproj
+++ b/example/ios/exmpl.xcodeproj/project.pbxproj
@@ -433,6 +433,7 @@
 			baseConfigurationReference = 5B7EB9410499542E8C5724F5 /* Pods-exmpl-exmplTests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
+				DEVELOPMENT_TEAM = KYH47R284B;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
 					"$(inherited)",
@@ -516,6 +517,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = KYH47R284B;
 				INFOPLIST_FILE = exmpl/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 13;
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/lib/android/src/main/java/com/reactnativeldk/LdkModule.kt
+++ b/lib/android/src/main/java/com/reactnativeldk/LdkModule.kt
@@ -54,7 +54,8 @@ enum class EventTypes {
     network_graph_updated,
     channel_manager_restarted,
     backup_state_update,
-    lsp_log
+    lsp_log,
+    used_close_address
 }
 //*****************************************************************
 
@@ -242,7 +243,7 @@ class LdkModule(reactContext: ReactApplicationContext) : ReactContextBaseJavaMod
     }
 
     @ReactMethod
-    fun initKeysManager(seed: String, destinationScriptPublicKey: String, witnessProgram: String, witnessProgramVersion: Double, promise: Promise) {
+    fun initKeysManager(seed: String, address: String, destinationScriptPublicKey: String, witnessProgram: String, witnessProgramVersion: Double, promise: Promise) {
         if (keysManager != null) {
             return handleResolve(promise, LdkCallbackResponses.keys_manager_init_success)
         }
@@ -259,11 +260,11 @@ class LdkModule(reactContext: ReactApplicationContext) : ReactContextBaseJavaMod
             seedBytes,
             seconds,
             nanoSeconds.toInt(),
+            address,
             destinationScriptPublicKey.hexa(),
             witnessProgram.hexa(),
             witnessProgramVersion.toInt().toByte()
         )
-        //keysManager = KeysManager.of(seedBytes, seconds, nanoSeconds.toInt())
 
         handleResolve(promise, LdkCallbackResponses.keys_manager_init_success)
     }

--- a/lib/android/src/main/java/com/reactnativeldk/classes/CustomKeysManager.kt
+++ b/lib/android/src/main/java/com/reactnativeldk/classes/CustomKeysManager.kt
@@ -22,6 +22,7 @@ class CustomKeysManager(
     seed: ByteArray,
     startingTimeSecs: Long,
     startingTimeNanos: Int,
+    val address: String,
     val destinationScriptPublicKey: ByteArray,
     val witnessProgram: ByteArray,
     val witnessProgramVersion: Byte
@@ -68,6 +69,7 @@ class CustomSignerProvider : SignerProviderInterface {
         val res = ShutdownScript.new_witness_program(witness)
 
         return if (res.is_ok) {
+            LdkEventEmitter.send(EventTypes.used_close_address, customKeysManager.address)
             Result_ShutdownScriptNoneZ.ok((res as Result_ShutdownScriptInvalidShutdownScriptZ.Result_ShutdownScriptInvalidShutdownScriptZ_OK).res)
         } else {
             Result_ShutdownScriptNoneZ.err()

--- a/lib/ios/Ldk.m
+++ b/lib/ios/Ldk.m
@@ -16,6 +16,7 @@ RCT_EXTERN_METHOD(writeToLogFile:(NSString *)line
 RCT_EXTERN_METHOD(initChainMonitor:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject)
 RCT_EXTERN_METHOD(initKeysManager:(NSString *)seed
+                  address:(NSString *)address
                   destinationScriptPublicKey:(NSString *)destinationScriptPublicKey
                   witnessProgram:(NSString *)witnessProgram
                   witnessProgramVersion:(NSInteger *)witnessProgramVersion                  

--- a/lib/ios/Ldk.swift
+++ b/lib/ios/Ldk.swift
@@ -26,6 +26,7 @@ enum EventTypes: String, CaseIterable {
     case channel_manager_restarted = "channel_manager_restarted"
     case backup_state_update = "backup_state_update"
     case lsp_log = "lsp_log"
+    case used_close_address = "used_close_address"
 }
 //*****************************************************************
 
@@ -210,7 +211,7 @@ class Ldk: NSObject {
     }
     
     @objc
-    func initKeysManager(_ seed: NSString, destinationScriptPublicKey: NSString, witnessProgram: NSString, witnessProgramVersion: NSInteger, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+    func initKeysManager(_ seed: NSString, address: NSString, destinationScriptPublicKey: NSString, witnessProgram: NSString, witnessProgramVersion: NSInteger, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
         if keysManager != nil {
             //If previously started with the same key (by backup client) return success.
             return handleResolve(resolve, .keys_manager_init_success)
@@ -228,6 +229,7 @@ class Ldk: NSObject {
             seed: String(seed).hexaBytes,
             startingTimeSecs: seconds,
             startingTimeNanos: nanoSeconds,
+            address: String(address),
             destinationScriptPublicKey: String(destinationScriptPublicKey).hexaBytes,
             witnessProgram: String(witnessProgram).hexaBytes,
             witnessProgramVersion: UInt8(witnessProgramVersion)

--- a/lib/ios/Ldk.swift
+++ b/lib/ios/Ldk.swift
@@ -663,7 +663,7 @@ class Ldk: NSObject {
             droppedPeerTimer = Timer.scheduledTimer(
                 timeInterval: 5.0,
                 target: self,
-                selector: #selector(handleDroppedPeers),
+                selector: #selector(self.handleDroppedPeers),
                 userInfo: nil,
                 repeats: true
             )

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@synonymdev/react-native-ldk",
   "title": "React Native LDK",
-  "version": "0.0.143",
+  "version": "0.0.145",
   "description": "React Native wrapper for LDK",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/lib/src/ldk.ts
+++ b/lib/src/ldk.ts
@@ -95,6 +95,7 @@ class LDK {
 	 */
 	async initKeysManager({
 		seed,
+		address,
 		channelCloseDestinationScriptPublicKey,
 		channelCloseWitnessProgram,
 		channelCloseWitnessProgramVersion,
@@ -102,6 +103,7 @@ class LDK {
 		try {
 			const res = await NativeLDK.initKeysManager(
 				seed,
+				address,
 				channelCloseDestinationScriptPublicKey,
 				channelCloseWitnessProgram,
 				channelCloseWitnessProgramVersion,

--- a/lib/src/utils/types.ts
+++ b/lib/src/utils/types.ts
@@ -35,6 +35,7 @@ export enum EEventTypes {
 	channel_manager_restarted = 'channel_manager_restarted',
 	backup_state_update = 'backup_state_update',
 	lsp_log = 'lsp_log',
+	used_close_address = 'used_close_address',
 }
 
 //LDK event responses
@@ -326,6 +327,7 @@ export type TDownloadScorer = {
 
 export type TInitKeysManager = {
 	seed: string;
+	address: string;
 	channelCloseDestinationScriptPublicKey: string;
 	channelCloseWitnessProgram: string;
 	channelCloseWitnessProgramVersion: number;


### PR DESCRIPTION
Previously we were persisting every new close address to file. This resulted in saving many addresses that may have not been used for a channel close.

Rather persist addresses:
- When confirmed to be used for shutdown script when accepting a channel (for coop closes)
- When sweeping outputs (from a force close).

This way Bitkit can use this address file to explicitly watch for any new txs and update the UI after a coop or force close.