### PR TITLE
feat: persist trusted peers to disk

### DIFF
--- a/example/ldk/index.ts
+++ b/example/ldk/index.ts
@@ -150,7 +150,6 @@ export const setupLdk = async (
 				},
 				manually_accept_inbound_channels: true,
 			},
-			trustedZeroConfPeers: [peers.lnd.pubKey],
 			skipRemoteBackups: !backupServerDetails,
 			lspLogEvent: async (payload) => {
 				console.log('Log event for LSP:', JSON.stringify(payload));
@@ -182,6 +181,15 @@ export const setupLdk = async (
 			console.log('addPeer Responses:', JSON.stringify(peersRes));
 		} catch (e) {
 			return err(e.toString());
+		}
+
+		//Set trusted peers we should accept zero conf channels from
+		const trustedPeers = Object.values(peers).map((peer) => peer.pubKey);
+		const trustedPeersRes = await lm.setTrustedZeroConfPeerNodeIds(
+			trustedPeers,
+		);
+		if (trustedPeersRes.isErr()) {
+			return err(trustedPeersRes.error.message);
 		}
 
 		const nodeIdRes = await ldk.nodeId();

--- a/lib/src/utils/types.ts
+++ b/lib/src/utils/types.ts
@@ -481,6 +481,7 @@ export enum ELdkFiles {
 	channel_manager = 'channel_manager.bin', //Serialised rust object
 	channels = 'channels', //Path containing multiple files of serialised channels
 	peers = 'peers.json', //File saved from JS
+	trusted_peer_node_ids = 'trusted_peer_node_ids.json', //File saved from JS
 	unconfirmed_transactions = 'unconfirmed_transactions.json',
 	broadcasted_transactions = 'broadcasted_transactions.json',
 	confirmed_broadcasted_transactions = 'confirmed_broadcasted_transactions.json',
@@ -571,7 +572,6 @@ export type TLdkStart = {
 	scorerDownloadUrl?: string;
 	forceCloseOnStartup?: TForceCloseOnStartup;
 	userConfig?: TUserConfig;
-	trustedZeroConfPeers?: string[];
 	skipParamCheck?: boolean;
 	skipRemoteBackups?: boolean;
 	lspLogEvent?: TLspLogEvent;


### PR DESCRIPTION
- Removed `trustedZeroConfPeers` from startup params
- `lm.setTrustedZeroConfPeerNodeIds(nodeIds)` can be used at any point in the app life cycle to update and persist the current list of trusted zero conf peers.