### PR TITLE
fix: spend outputs script checks unconfirmed and confirmed broadcasted txs

### DIFF
--- a/lib/android/src/main/java/com/reactnativeldk/LdkModule.kt
+++ b/lib/android/src/main/java/com/reactnativeldk/LdkModule.kt
@@ -1228,7 +1228,7 @@ class LdkModule(reactContext: ReactApplicationContext) : ReactContextBaseJavaMod
     }
 
     @ReactMethod
-    fun spendRecoveredForceCloseOutputs(transaction: String, confirmationHeight: Double, changeDestinationScript: String, promise: Promise) {
+    fun spendRecoveredForceCloseOutputs(transaction: String, confirmationHeight: Double, changeDestinationScript: String, useInner: Boolean, promise: Promise) {
         if (channelStoragePath == "") {
             return handleReject(promise, LdkErrors.init_storage_path)
         }
@@ -1270,13 +1270,23 @@ class LdkModule(reactContext: ReactApplicationContext) : ReactContextBaseJavaMod
                     continue
                 }
 
-                val res = keysManager!!.spend_spendable_outputs(
-                    descriptors,
-                    emptyArray(),
-                    changeDestinationScript.hexa(),
-                    feeEstimator.onChainSweep,
-                    Option_u32Z.none()
-                )
+                val res = if (useInner) {
+                    keysManager!!.inner.spend_spendable_outputs(
+                        descriptors,
+                        emptyArray(),
+                        changeDestinationScript.hexa(),
+                        feeEstimator.onChainSweep,
+                        Option_u32Z.none()
+                    )
+                } else {
+                    keysManager!!.spend_spendable_outputs(
+                        descriptors,
+                        emptyArray(),
+                        changeDestinationScript.hexa(),
+                        feeEstimator.onChainSweep,
+                        Option_u32Z.none()
+                    )
+                }
 
                 if (res.is_ok) {
                     txs.pushHexString((res as Result_TransactionNoneZ.Result_TransactionNoneZ_OK).res)

--- a/lib/ios/Ldk.m
+++ b/lib/ios/Ldk.m
@@ -176,6 +176,7 @@ RCT_EXTERN_METHOD(reconstructAndSpendOutputs:(NSString *)outputScriptPubKey
 RCT_EXTERN_METHOD(spendRecoveredForceCloseOutputs:(NSString *)transaction
                   confirmationHeight:(NSInteger *)confirmationHeight
                   changeDestinationScript:(NSString *)changeDestinationScript
+                  useInner:(BOOL *)useInner
                   resolve:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject)
 RCT_EXTERN_METHOD(nodeSign:(NSString *)message

--- a/lib/ios/Ldk.swift
+++ b/lib/ios/Ldk.swift
@@ -507,7 +507,7 @@ class Ldk: NSObject {
         currentBlockchainHeight = blockHeight
         addForegroundObserver()
         startDroppedPeerTimer()
-                
+        
         return handleResolve(resolve, .channel_manager_init_success)
     }
     
@@ -659,7 +659,7 @@ class Ldk: NSObject {
             guard let self else { return }
             
             LdkEventEmitter.shared.send(withEvent: .native_log, body: "Starting timer to check for dropped peers")
-
+            
             droppedPeerTimer = Timer.scheduledTimer(
                 timeInterval: 5.0,
                 target: self,
@@ -1385,7 +1385,7 @@ class Ldk: NSObject {
     }
     
     @objc
-    func spendRecoveredForceCloseOutputs(_ transaction: NSString, confirmationHeight: NSInteger, changeDestinationScript: NSString, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+    func spendRecoveredForceCloseOutputs(_ transaction: NSString, confirmationHeight: NSInteger, changeDestinationScript: NSString, useInner: Bool, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
         
         guard let channelStoragePath = Ldk.channelStoragePath, let keysManager, let channelManager else {
             return handleReject(reject, .init_storage_path)
@@ -1428,7 +1428,14 @@ class Ldk: NSObject {
                 continue
             }
             
-            let res = keysManager.spendSpendableOutputs(
+            let res = useInner ? keysManager.inner.spendSpendableOutputs(
+                descriptors: descriptors,
+                outputs: [],
+                changeDestinationScript: String(changeDestinationScript).hexaBytes,
+                feerateSatPer1000Weight: feeEstimator.getEstSatPer1000Weight(confirmationTarget: .OnChainSweep),
+                locktime: nil)
+            :
+            keysManager.spendSpendableOutputs(
                 descriptors: descriptors,
                 outputs: [],
                 changeDestinationScript: String(changeDestinationScript).hexaBytes,

--- a/lib/src/ldk.ts
+++ b/lib/src/ldk.ts
@@ -1249,12 +1249,14 @@ class LDK {
 		transaction,
 		confirmationHeight,
 		changeDestinationScript,
+		useInner,
 	}: TSpendRecoveredForceCloseOutputsReq): Promise<Result<string[]>> {
 		try {
 			const res = await NativeLDK.spendRecoveredForceCloseOutputs(
 				transaction,
 				confirmationHeight,
 				changeDestinationScript,
+				useInner,
 			);
 			this.writeDebugToLog('spendRecoveredForceCloseOutputs', res);
 			return ok(res);

--- a/lib/src/utils/types.ts
+++ b/lib/src/utils/types.ts
@@ -150,7 +150,7 @@ export type TChannel = {
 	balance_sat: number;
 	counterparty_node_id: string;
 	funding_txid?: string;
-	funding_output_index? : number;
+	funding_output_index?: number;
 	channel_type?: string;
 	user_channel_id: string;
 	confirmations_required?: number;
@@ -613,6 +613,7 @@ export type TSpendRecoveredForceCloseOutputsReq = {
 	transaction: string;
 	confirmationHeight: number;
 	changeDestinationScript: string;
+	useInner: boolean;
 };
 
 export type TBackupServerDetails = {


### PR DESCRIPTION
Fixes a bug where very old channels that were opened before the custom key chain were not being swept and the helper script to attempt to spend the outputs again was not using archived transaction list.