### PR TITLE
Android: Fix crash in handleDroppedPeers

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ cd ios && pod install && cd ../
 ### Android
 - Open `lib/android` in Android Studio
 - To enable documentation for the LDK code, follow this guide: [How to attach JavaDoc to the library in Android Studio](https://medium.com/@mydogtom/tip-how-to-attach-javadoc-to-the-library-in-android-studio-5ff43c4303b3), ie.:
-  1. Switch to `Project` view in the Project browser tool windo
+  1. Switch to `Project` view in the Project browser tool window
   2. Expand `External Libraries`
   3. Right click on `Gradle: ./libs/LDK-release.aar` then `Library Properties…`
   4. Tap the ➕ button and select the `./lib/android/libs/ldk-java-javadoc.jar` file

--- a/README.md
+++ b/README.md
@@ -39,6 +39,15 @@ cd ios && pod install && cd ../
   4. Tap the ➕ button and select the `./lib/android/libs/ldk-java-javadoc.jar` file
   5. In the popup that appears select `JavaDocs` and tap `OK` then `OK` again
 
+### Version Bump
+```sh
+# apply your changes
+cd example
+yarn reinstall # bump versions package.json & podfile
+cd ../
+# copy version from `./lib/package.json` to `backup-server/package.json`
+
+```
 ## Running example app
 See also [`./example/README.md`](./example/README.md)
 ```bash

--- a/backup-server/package.json
+++ b/backup-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backup-server",
-  "version": "0.0.146",
+  "version": "0.0.151",
   "description": "",
   "main": "index.js",
   "engines": {

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -316,7 +316,7 @@ PODS:
   - React-jsinspector (0.72.4)
   - React-logger (0.72.4):
     - glog
-  - react-native-ldk (0.0.150):
+  - react-native-ldk (0.0.151):
     - React
   - react-native-randombytes (3.6.1):
     - React-Core
@@ -621,7 +621,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: c7f826e40fa9cab5d37cab6130b1af237332b594
   React-jsinspector: aaed4cf551c4a1c98092436518c2d267b13a673f
   React-logger: da1ebe05ae06eb6db4b162202faeafac4b435e77
-  react-native-ldk: 2b19de9eb94dcfd46f3f2a7191502292b75a5d7a
+  react-native-ldk: a7e71785237dd3d12dc52b4287abd88c865f5262
   react-native-randombytes: 421f1c7d48c0af8dbcd471b0324393ebf8fe7846
   react-native-tcp-socket: c1b7297619616b4c9caae6889bcb0aba78086989
   React-NativeModulesApple: edb5ace14f73f4969df6e7b1f3e41bef0012740f

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@synonymdev/react-native-ldk",
   "title": "React Native LDK",
-  "version": "0.0.150",
+  "version": "0.0.151",
   "description": "React Native wrapper for LDK",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
Fixes synonymdev/bitkit#2133

(Android-only) Fix to avoid `ConcurrentModificationException` while `addedPeers` list is modified from other thread.

Former setup:
1. Scheduling was done using `TimerTask` which creates a different thread each time it's invoked
2. Since we also change `addedPeers` from react-native, there was a chance to get into this issue especially at app start, when both the react-native code as well as the native LDKModule code would mutate the same list.

Fix:
Use a thread-safe mutable list implementation, I picked `ConcurrentLinkedQueue` because it's less resource-consuming than other options.

Extra:
Rewrote the implementation of the scheduled repeating task, to use more performant and adequate APIs which actually wait for the scheduled work to finish, then delay the next execution with 3 seconds.