### PR TITLE
fix: gets peer message when manual open channel fails

### DIFF
--- a/lib/android/src/main/java/com/reactnativeldk/classes/LdkChannelManagerPersister.kt
+++ b/lib/android/src/main/java/com/reactnativeldk/classes/LdkChannelManagerPersister.kt
@@ -162,6 +162,14 @@ class LdkChannelManagerPersister: ChannelManagerConstructor.EventHandler {
             }
             body.putString("reason", reasonString)
 
+            if (channelClosed.reason is ClosureReason.CounterpartyForceClosed) {
+                (channelClosed.reason as ClosureReason.CounterpartyForceClosed).peer_msg?.let {
+                    body.putString("peer_message", it.to_str())
+                }
+            }
+
+            println("Channel closed: ${channelClosed.channel_id._a.hexEncodedString()}")
+
             return LdkEventEmitter.send(EventTypes.channel_manager_channel_closed, body)
         }
 

--- a/lib/ios/Ldk.swift
+++ b/lib/ios/Ldk.swift
@@ -937,6 +937,25 @@ class Ldk: NSObject {
             return resolve(Data(res.getValue()?.getA() ?? []).hexEncodedString())
         }
         
+        if let error = res.getError() {
+            switch error.getValueType() {
+            case .APIMisuseError:
+                return handleReject(reject, .start_create_channel_fail, nil, error.getValueAsApiMisuseError()?.getErr())
+            case .ChannelUnavailable:
+                return handleReject(reject, .start_create_channel_fail, nil, error.getValueAsChannelUnavailable()?.getErr())
+            case .FeeRateTooHigh:
+                return handleReject(reject, .start_create_channel_fail, nil, error.getValueAsFeeRateTooHigh()?.getErr())
+            case .InvalidRoute:
+                return handleReject(reject, .start_create_channel_fail, nil, error.getValueAsInvalidRoute()?.getErr())
+            case .IncompatibleShutdownScript:
+                return handleReject(reject, .start_create_channel_fail, nil, "IncompatibleShutdownScript")
+            case .MonitorUpdateInProgress:
+                return handleReject(reject, .start_create_channel_fail, nil, "MonitorUpdateInProgress")
+            @unknown default:
+                handleReject(reject, .start_create_channel_fail, "Unhandled error")
+            }
+        }
+        
         handleReject(reject, .start_create_channel_fail)
     }
     

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@synonymdev/react-native-ldk",
   "title": "React Native LDK",
-  "version": "0.0.151",
+  "version": "0.0.152",
   "description": "React Native wrapper for LDK",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/lib/src/lightning-manager.ts
+++ b/lib/src/lightning-manager.ts
@@ -2449,7 +2449,7 @@ class LightningManager {
 		return new Promise((resolve, reject) => {
 			// Channel funding ready event should be instant but if it fails and we don't get the event, we should reject.
 			const timeout = setTimeout(() => {
-				reject(err(new Error('Event not triggered within 5 seconds')));
+				resolve(err(new Error('Event not triggered within 5 seconds')));
 			}, 5000);
 
 			// Listen for the event for the channel funding details
@@ -2465,8 +2465,14 @@ class LightningManager {
 				EEventTypes.channel_manager_channel_closed,
 				(eventRes: TChannelManagerChannelClosed) => {
 					if (eventRes.channel_id === res.value) {
+
 						clearTimeout(timeout);
-						reject(err('Channel closed before funding'));
+						if (eventRes.peer_message) {
+							resolve(err(eventRes.peer_message));
+							return;
+						}
+
+						resolve(err(`Channel open failed: ${eventRes.reason}`));
 					}
 				},
 			);

--- a/lib/src/utils/types.ts
+++ b/lib/src/utils/types.ts
@@ -134,6 +134,7 @@ export type TChannelManagerChannelClosed = {
 	user_channel_id: string;
 	channel_id: string;
 	reason: string;
+	peer_message?: string;
 };
 
 export type TChannelManagerDiscardFunding = {


### PR DESCRIPTION
- Returns specific errors from `channelManager.createChannel` when possible
- Adds `peer_message` to `channel_manager_channel_closed` event when exists
- `lm.createChannel(...)` returns peer message as the error string if it exists

![Screenshot 2024-09-20 at 10 51 10](https://github.com/user-attachments/assets/cd8dacc5-dbb5-4d34-92c8-09efea5a0fd5)
