### PR TITLE
feat: enable trace logs for payments

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -316,7 +316,7 @@ PODS:
   - React-jsinspector (0.72.4)
   - React-logger (0.72.4):
     - glog
-  - react-native-ldk (0.0.152):
+  - react-native-ldk (0.0.154):
     - React
   - react-native-randombytes (3.6.1):
     - React-Core
@@ -621,7 +621,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: c7f826e40fa9cab5d37cab6130b1af237332b594
   React-jsinspector: aaed4cf551c4a1c98092436518c2d267b13a673f
   React-logger: da1ebe05ae06eb6db4b162202faeafac4b435e77
-  react-native-ldk: 1d25080cfadac349eab355725da66de140fbc7a8
+  react-native-ldk: 6910154336e57be6702a33acad2191d39a3a214b
   react-native-randombytes: 421f1c7d48c0af8dbcd471b0324393ebf8fe7846
   react-native-tcp-socket: c1b7297619616b4c9caae6889bcb0aba78086989
   React-NativeModulesApple: edb5ace14f73f4969df6e7b1f3e41bef0012740f

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@synonymdev/react-native-ldk",
   "title": "React Native LDK",
-  "version": "0.0.152",
+  "version": "0.0.154",
   "description": "React Native wrapper for LDK",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
Enables trace logging for the duration of `payWithTimeout` + 10 seconds. So we can get details on paths attempted:

```
2025-01-29 14:06:28 UTC TRACE (LDK): Found a path back to us from the target with 1 hops contributing up to 22000 msat: 
 [
    PathBuildingHop {
        node_id: Some(
            NodeId(0341e41583ad691951634e24dd20252d13feace9286a85d47f220dde74e7e09a15),
        ),
        short_channel_id: Some(
            13613053463560193,
        ),
        total_fee_msat: 0,
        next_hops_fee_msat: 0,
        hop_use_fee_msat: 0,
        total_fee_msat - (next_hops_fee_msat + hop_use_fee_msat): 0,
        path_penalty_msat: 0,
        path_htlc_minimum_msat: 1,
        cltv_expiry_delta: 0,
    },
] (lightning::routing::router 2834)
```