### PR TITLE
chore: mock readAddressesFromFile()

### DIFF
--- a/lib/src/mock.ts
+++ b/lib/src/mock.ts
@@ -33,6 +33,7 @@ export default {
 	appendLdkPaymentId: noop,
 	getLdkUnconfirmedTxs: noop,
 	getLdkSpendableOutputs: noop,
+	readAddressesFromFile: noop,
 	saveUnconfirmedTxs: noop,
 	saveBroadcastedTxs: noop,
 	saveLdkPeerData: noop,


### PR DESCRIPTION
Should remove warnings in Bitkit unit tests